### PR TITLE
Ensure dismiss action for AccountSetupSheet is anchored correctly

### DIFF
--- a/ENGAGEHF.xcodeproj/project.pbxproj
+++ b/ENGAGEHF.xcodeproj/project.pbxproj
@@ -90,6 +90,7 @@
 		A9A0BF032C13121D00B8F3F3 /* SpeziNumerics in Frameworks */ = {isa = PBXBuildFile; productRef = A9A0BF022C13121D00B8F3F3 /* SpeziNumerics */; };
 		A9D83F962B083794000D0C78 /* SpeziFirebaseAccountStorage in Frameworks */ = {isa = PBXBuildFile; productRef = A9D83F952B083794000D0C78 /* SpeziFirebaseAccountStorage */; };
 		A9DFE8A92ABE551400428242 /* AccountButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9DFE8A82ABE551400428242 /* AccountButton.swift */; };
+		A9F2138E2C18EBAB00A7578F /* AccountTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9F2138D2C18EBAB00A7578F /* AccountTests.swift */; };
 		A9FE7AD02AA39BAB0077B045 /* AccountSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9FE7ACF2AA39BAB0077B045 /* AccountSheet.swift */; };
 /* End PBXBuildFile section */
 
@@ -171,6 +172,7 @@
 		A996F45B2C11AA15002328C5 /* BloodPressureMeasurementLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BloodPressureMeasurementLabel.swift; sourceTree = "<group>"; };
 		A996F45D2C11B793002328C5 /* BoodPressureCuffTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoodPressureCuffTests.swift; sourceTree = "<group>"; };
 		A9DFE8A82ABE551400428242 /* AccountButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountButton.swift; sourceTree = "<group>"; };
+		A9F2138D2C18EBAB00A7578F /* AccountTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountTests.swift; sourceTree = "<group>"; };
 		A9FE7ACF2AA39BAB0077B045 /* AccountSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountSheet.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -384,6 +386,7 @@
 				4D4AA0A42BC5E43E00676489 /* OnboardingUITests.swift */,
 				A96C56B52C0A149B00D6A50B /* WeightScaleTests.swift */,
 				A996F45D2C11B793002328C5 /* BoodPressureCuffTests.swift */,
+				A9F2138D2C18EBAB00A7578F /* AccountTests.swift */,
 			);
 			path = ENGAGEHFUITests;
 			sourceTree = "<group>";
@@ -398,11 +401,11 @@
 		A9720E412ABB68B300872D23 /* Account */ = {
 			isa = PBXGroup;
 			children = (
-				A9FE7ACF2AA39BAB0077B045 /* AccountSheet.swift */,
-				A9720E422ABB68CC00872D23 /* AccountSetupHeader.swift */,
 				A9DFE8A82ABE551400428242 /* AccountButton.swift */,
-				A96C56BA2C0DFFCE00D6A50B /* InvitationCodeModule.swift */,
+				A9720E422ABB68CC00872D23 /* AccountSetupHeader.swift */,
 				A9623C072C18D03F00189BA1 /* AccountSetupSheet.swift */,
+				A9FE7ACF2AA39BAB0077B045 /* AccountSheet.swift */,
+				A96C56BA2C0DFFCE00D6A50B /* InvitationCodeModule.swift */,
 			);
 			path = Account;
 			sourceTree = "<group>";
@@ -680,6 +683,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				A96C56B62C0A149B00D6A50B /* WeightScaleTests.swift in Sources */,
+				A9F2138E2C18EBAB00A7578F /* AccountTests.swift in Sources */,
 				4D4AA0A52BC5E43E00676489 /* OnboardingUITests.swift in Sources */,
 				2F4E237E2989A2FE0013F3D9 /* LaunchTests.swift in Sources */,
 				4DB025CA2BBE3A59002D2545 /* HomeViewUITests.swift in Sources */,
@@ -1226,8 +1230,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/StanfordSpezi/SpeziFirebase.git";
 			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 1.0.0;
+				branch = "fix/name-ignored-account-linking";
+				kind = branch;
 			};
 		};
 		2FE5DC8229EDD934004B9AB4 /* XCRemoteSwiftPackageReference "SpeziQuestionnaire" */ = {

--- a/ENGAGEHF.xcodeproj/project.pbxproj
+++ b/ENGAGEHF.xcodeproj/project.pbxproj
@@ -71,6 +71,7 @@
 		9739A0C62AD7B5730084BEA5 /* FirebaseStorage in Frameworks */ = {isa = PBXBuildFile; productRef = 9739A0C52AD7B5730084BEA5 /* FirebaseStorage */; };
 		97D73D6A2AD860AD00B47FA0 /* SpeziFirebaseStorage in Frameworks */ = {isa = PBXBuildFile; productRef = 97D73D692AD860AD00B47FA0 /* SpeziFirebaseStorage */; };
 		A92E4DF02BAA001100AC8DE8 /* OrderedCollections in Frameworks */ = {isa = PBXBuildFile; productRef = A92E4DEF2BAA001100AC8DE8 /* OrderedCollections */; };
+		A9623C082C18D03F00189BA1 /* AccountSetupSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9623C072C18D03F00189BA1 /* AccountSetupSheet.swift */; };
 		A96C56B62C0A149B00D6A50B /* WeightScaleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A96C56B52C0A149B00D6A50B /* WeightScaleTests.swift */; };
 		A96C56BB2C0DFFCE00D6A50B /* InvitationCodeModule.swift in Sources */ = {isa = PBXBuildFile; fileRef = A96C56BA2C0DFFCE00D6A50B /* InvitationCodeModule.swift */; };
 		A96C56BF2C0E334A00D6A50B /* BloodPressureCuffDevice.swift in Sources */ = {isa = PBXBuildFile; fileRef = A96C56BE2C0E334A00D6A50B /* BloodPressureCuffDevice.swift */; };
@@ -153,6 +154,7 @@
 		653A256128338800005D4D48 /* ENGAGEHFTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ENGAGEHFTests.swift; sourceTree = "<group>"; };
 		653A256728338800005D4D48 /* ENGAGEHFUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ENGAGEHFUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		653A258928339462005D4D48 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		A9623C072C18D03F00189BA1 /* AccountSetupSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountSetupSheet.swift; sourceTree = "<group>"; };
 		A96C56B52C0A149B00D6A50B /* WeightScaleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeightScaleTests.swift; sourceTree = "<group>"; };
 		A96C56BA2C0DFFCE00D6A50B /* InvitationCodeModule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InvitationCodeModule.swift; sourceTree = "<group>"; };
 		A96C56BE2C0E334A00D6A50B /* BloodPressureCuffDevice.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BloodPressureCuffDevice.swift; sourceTree = "<group>"; };
@@ -400,6 +402,7 @@
 				A9720E422ABB68CC00872D23 /* AccountSetupHeader.swift */,
 				A9DFE8A82ABE551400428242 /* AccountButton.swift */,
 				A96C56BA2C0DFFCE00D6A50B /* InvitationCodeModule.swift */,
+				A9623C072C18D03F00189BA1 /* AccountSetupSheet.swift */,
 			);
 			path = Account;
 			sourceTree = "<group>";
@@ -631,6 +634,7 @@
 				2FC975A82978F11A00BA99FE /* Home.swift in Sources */,
 				4DDFC7792BFB4E7D002B07A1 /* CloseButtonLayer.swift in Sources */,
 				4DDFC7762BFB46FF002B07A1 /* MeasurementLayer.swift in Sources */,
+				A9623C082C18D03F00189BA1 /* AccountSetupSheet.swift in Sources */,
 				4DB025D52BBF2E08002D2545 /* Dashboard.swift in Sources */,
 				A9DFE8A92ABE551400428242 /* AccountButton.swift in Sources */,
 				2FE5DC3729EDD7CA004B9AB4 /* OnboardingFlow.swift in Sources */,

--- a/ENGAGEHF.xcodeproj/project.pbxproj
+++ b/ENGAGEHF.xcodeproj/project.pbxproj
@@ -1230,8 +1230,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/StanfordSpezi/SpeziFirebase.git";
 			requirement = {
-				branch = "fix/name-ignored-account-linking";
-				kind = branch;
+				kind = upToNextMajorVersion;
+				minimumVersion = 1.1.2;
 			};
 		};
 		2FE5DC8229EDD934004B9AB4 /* XCRemoteSwiftPackageReference "SpeziQuestionnaire" */ = {

--- a/ENGAGEHF.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ENGAGEHF.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "7a1ae4cd835f2e84578822a40fc673f29fc7ab26c0416a0079ce8402bbb3da0b",
+  "originHash" : "4680bbbdca4179318420f5e90c76b7b5892a3fbaf02dc6668d80ce474e195a4d",
   "pins" : [
     {
       "identity" : "abseil-cpp-binary",
@@ -321,8 +321,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-collections.git",
       "state" : {
-        "revision" : "94cf62b3ba8d4bed62680a282d4c25f9c63c2efb",
-        "version" : "1.1.0"
+        "revision" : "ee97538f5b81ae89698fd95938896dec5217b148",
+        "version" : "1.1.1"
       }
     },
     {
@@ -339,8 +339,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/FelixHerrmann/swift-package-list",
       "state" : {
-        "revision" : "9e7edc38f2a599424b9437c32baf1e6a8b9621b8",
-        "version" : "4.1.0"
+        "revision" : "01f2e9860c122dd8c3ae2a7e642b85bbb053efe3",
+        "version" : "4.2.0"
       }
     },
     {

--- a/ENGAGEHF.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ENGAGEHF.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -222,8 +222,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/StanfordSpezi/SpeziFirebase.git",
       "state" : {
-        "revision" : "f05c859f75d317dca9b378b7f8a7cfa8e135df04",
-        "version" : "1.1.1"
+        "branch" : "fix/name-ignored-account-linking",
+        "revision" : "faef99a42ff2c3faee5998a94aee3f5a0d8be38c"
       }
     },
     {

--- a/ENGAGEHF.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ENGAGEHF.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -222,8 +222,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/StanfordSpezi/SpeziFirebase.git",
       "state" : {
-        "branch" : "fix/name-ignored-account-linking",
-        "revision" : "d62c065bc86105e42cb6b3716cebc47e98351344"
+        "revision" : "00ff0db12bf72ba39354e263d8f916ae8392368b",
+        "version" : "1.1.2"
       }
     },
     {

--- a/ENGAGEHF.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ENGAGEHF.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -223,7 +223,7 @@
       "location" : "https://github.com/StanfordSpezi/SpeziFirebase.git",
       "state" : {
         "branch" : "fix/name-ignored-account-linking",
-        "revision" : "faef99a42ff2c3faee5998a94aee3f5a0d8be38c"
+        "revision" : "d62c065bc86105e42cb6b3716cebc47e98351344"
       }
     },
     {

--- a/ENGAGEHF.xcodeproj/xcshareddata/xcschemes/ENGAGEHF.xcscheme
+++ b/ENGAGEHF.xcodeproj/xcshareddata/xcschemes/ENGAGEHF.xcscheme
@@ -82,8 +82,12 @@
             isEnabled = "NO">
          </CommandLineArgument>
          <CommandLineArgument
+            argument = "--assumeOnboardingComplete"
+            isEnabled = "YES">
+         </CommandLineArgument>
+         <CommandLineArgument
             argument = "--setupTestEnvironment"
-            isEnabled = "NO">
+            isEnabled = "YES">
          </CommandLineArgument>
          <CommandLineArgument
             argument = "--testMockDevices"
@@ -95,7 +99,7 @@
          </CommandLineArgument>
          <CommandLineArgument
             argument = "--skipOnboarding"
-            isEnabled = "YES">
+            isEnabled = "NO">
          </CommandLineArgument>
          <CommandLineArgument
             argument = "--testSchedule"

--- a/ENGAGEHF/Account/AccountSetupSheet.swift
+++ b/ENGAGEHF/Account/AccountSetupSheet.swift
@@ -14,9 +14,16 @@ import SwiftUI
 struct AccountSetupSheet: View {
     @Environment(\.dismiss) private var dismiss
 
+    @Environment(Account.self) private var account
+
     var body: some View {
         OnboardingStack {
             InvitationCodeView()
+                .onChange(of: account.signedIn, initial: true) {
+                    if account.signedIn {
+                        dismiss()
+                    }
+                }
             AccountSetup { _ in
                 dismiss()
             } header: {

--- a/ENGAGEHF/Account/AccountSetupSheet.swift
+++ b/ENGAGEHF/Account/AccountSetupSheet.swift
@@ -11,19 +11,29 @@ import SpeziOnboarding
 import SwiftUI
 
 
-struct AccountSetupSheet: View {
+private struct AccountInvitationCodeView: View {
     @Environment(\.dismiss) private var dismiss
 
     @Environment(Account.self) private var account
 
+
+    var body: some View {
+        InvitationCodeView()
+            .onChange(of: account.signedIn, initial: true) {
+                if account.signedIn {
+                    dismiss()
+                }
+            }
+    }
+}
+
+
+struct AccountSetupSheet: View {
+    @Environment(\.dismiss) private var dismiss
+
     var body: some View {
         OnboardingStack {
-            InvitationCodeView()
-                .onChange(of: account.signedIn, initial: true) {
-                    if account.signedIn {
-                        dismiss()
-                    }
-                }
+            AccountInvitationCodeView() // we need this indirection, otherwise the onChange doesn't trigger
             AccountSetup { _ in
                 dismiss()
             } header: {

--- a/ENGAGEHF/Account/AccountSetupSheet.swift
+++ b/ENGAGEHF/Account/AccountSetupSheet.swift
@@ -1,0 +1,43 @@
+//
+// This source file is part of the ENGAGE-HF project based on the Stanford Spezi Template Application project
+//
+// SPDX-FileCopyrightText: 2023 Stanford University
+//
+// SPDX-License-Identifier: MIT
+//
+
+import SpeziAccount
+import SpeziOnboarding
+import SwiftUI
+
+
+struct AccountSetupSheet: View {
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        OnboardingStack {
+            InvitationCodeView()
+            AccountSetup { _ in
+                dismiss()
+            } header: {
+                AccountSetupHeader()
+            }
+        }
+    }
+}
+
+
+#if DEBUG
+#Preview {
+    Text(verbatim: "Base View")
+        .sheet(isPresented: .constant(true)) {
+            AccountSetupSheet()
+        }
+        .previewWith {
+            AccountConfiguration {
+                MockUserIdPasswordAccountService()
+            }
+            InvitationCodeModule()
+        }
+}
+#endif

--- a/ENGAGEHF/Account/InvitationCodeModule.swift
+++ b/ENGAGEHF/Account/InvitationCodeModule.swift
@@ -86,6 +86,7 @@ class InvitationCodeModule: Module, EnvironmentAccessible {
 
         if let details = account.details,
            details.email == email {
+            logger.debug("Test account was already set up")
             return
         }
 
@@ -97,6 +98,7 @@ class InvitationCodeModule: Module, EnvironmentAccessible {
             try await service.login(userId: email, password: password)
             return // account was already established previously
         } catch {
+            logger.debug("We failed to login with test account. This might be expected if it is a fresh installation: \(error)")
             // probably doesn't exists. We try to create a new one below
         }
 

--- a/ENGAGEHF/ENGAGEHFTestingSetup.swift
+++ b/ENGAGEHF/ENGAGEHFTestingSetup.swift
@@ -22,7 +22,7 @@ private struct ENGAGEHFAppTestingSetup: ViewModifier {
     func body(content: Content) -> some View {
         content
             .task {
-                if FeatureFlags.skipOnboarding {
+                if FeatureFlags.assumeOnboardingComplete {
                     completedOnboardingFlow = true
                 }
                 if FeatureFlags.showOnboarding {

--- a/ENGAGEHF/Home.swift
+++ b/ENGAGEHF/Home.swift
@@ -53,14 +53,7 @@ struct HomeView: View {
                 AccountSheet()
             }
             .accountRequired(Self.accountEnabled) {
-                OnboardingStack {
-                    InvitationCodeView()
-                    AccountSetup { _ in
-                        dismiss()
-                    } header: {
-                        AccountSetupHeader()
-                    }
-                }
+                AccountSetupSheet()
             }
             .verifyRequiredAccountDetails(Self.accountEnabled)
             .sheet(item: $measurementManager.newMeasurement) { measurement in

--- a/ENGAGEHF/SharedContext/FeatureFlags.swift
+++ b/ENGAGEHF/SharedContext/FeatureFlags.swift
@@ -12,6 +12,8 @@ enum FeatureFlags {
     static let skipOnboarding = CommandLine.arguments.contains("--skipOnboarding")
     /// Always show the onboarding when the application is launched. Makes it easy to modify and test the onboarding flow without the need to manually remove the application or reset the simulator.
     static let showOnboarding = CommandLine.arguments.contains("--showOnboarding")
+    /// Set the onboarding completed flag to true. Doesn't disable account related functionality.
+    static let assumeOnboardingComplete = CommandLine.arguments.contains("--assumeOnboardingComplete") || skipOnboarding
     /// Disables the Firebase interactions, including the login/sign-up step and the Firebase Firestore upload.
     static let disableFirebase = CommandLine.arguments.contains("--disableFirebase")
     #if targetEnvironment(simulator)

--- a/ENGAGEHFUITests/AccountTests.swift
+++ b/ENGAGEHFUITests/AccountTests.swift
@@ -1,0 +1,63 @@
+//
+// This source file is part of the ENGAGE-HF project based on the Stanford Spezi Template Application project
+//
+// SPDX-FileCopyrightText: 2024 Stanford University
+//
+// SPDX-License-Identifier: MIT
+//
+
+import XCTest
+import XCTestExtensions
+
+
+final class AccountTests: XCTestCase {
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+
+        continueAfterFailure = false
+
+        let app = XCUIApplication()
+        app.launchArguments = ["--assumeOnboardingComplete", "--setupTestEnvironment"]
+        app.launch()
+    }
+
+    func testInAppLogon() throws {
+        let app = XCUIApplication()
+
+
+        XCTAssert(app.buttons["Home"].waitForExistence(timeout: 2.0))
+        app.buttons["Home"].tap()
+
+
+        XCTAssertTrue(app.navigationBars.buttons["Your Account"].waitForExistence(timeout: 2))
+        app.navigationBars.buttons["Your Account"].tap()
+
+        XCTAssert(app.buttons["Logout"].waitForExistence(timeout: 2))
+        app.buttons["Logout"].tap()
+
+        let alert = "Are you sure you want to logout?"
+        XCTAssert(app.alerts[alert].waitForExistence(timeout: 6.0))
+        app.alerts[alert].buttons["Logout"].tap()
+
+        sleep(2)
+
+
+        // Login
+        if app.buttons["I Already Have an Account"].waitForExistence(timeout: 2.0) {
+            app.buttons["I Already Have an Account"].tap()
+        }
+
+        XCTAssert(app.textFields["E-Mail Address"].waitForExistence(timeout: 2))
+        try app.textFields["E-Mail Address"].enter(value: "test@engage.stanford.edu")
+
+        XCTAssert(app.secureTextFields["Password"].waitForExistence(timeout: 2))
+        try app.secureTextFields["Password"].enter(value: "123456789")
+
+        XCTAssertTrue(app.buttons["Login"].waitForExistence(timeout: 0.5))
+        app.buttons["Login"].tap()
+
+        // ensure home view is in focus
+        XCTAssert(app.buttons["Home"].waitForExistence(timeout: 2.0))
+        app.buttons["Home"].tap()
+    }
+}

--- a/ENGAGEHFUITests/OnboardingUITests.swift
+++ b/ENGAGEHFUITests/OnboardingUITests.swift
@@ -105,15 +105,6 @@ extension XCUIApplication {
         buttons["Signup"].tap()
         
         try createAccount(email: email)
-        
-        // Finish Account Setup: Will possibly be removed
-        XCTAssert(staticTexts["Finish Account Setup"].waitForExistence(timeout: 5))
-
-        // TODO: issue with date of birth still persists?
-
-        // Complete Account
-        XCTAssert(buttons["Complete"].waitForExistence(timeout: 2) && buttons["Complete"].isEnabled)
-        buttons["Complete"].tap()
     }
     
     private func createAccount(email: String) throws {

--- a/ENGAGEHFUITests/OnboardingUITests.swift
+++ b/ENGAGEHFUITests/OnboardingUITests.swift
@@ -108,17 +108,9 @@ extension XCUIApplication {
         
         // Finish Account Setup: Will possibly be removed
         XCTAssert(staticTexts["Finish Account Setup"].waitForExistence(timeout: 5))
-        
-        // Enter first name
-        XCTAssert(textFields["enter first name"].exists)
-        textFields["enter first name"].tap()
-        textFields["enter first name"].typeText("Leland")
-        
-        // Enter last name
-        XCTAssert(textFields["enter last name"].exists)
-        textFields["enter last name"].tap()
-        textFields["enter last name"].typeText("Stanford")
-        
+
+        // TODO: issue with date of birth still persists?
+
         // Complete Account
         XCTAssert(buttons["Complete"].waitForExistence(timeout: 2) && buttons["Complete"].isEnabled)
         buttons["Complete"].tap()


### PR DESCRIPTION
# Ensure dismiss action for AccountSetupSheet is anchored correctly

## :recycle: Current situation & Problem
Fixes the issue described in #18, where the Account Setup sheet wouldn't disappear after successfully logging in.
Further this PR fixes the issue where the display name wouldn't be saved upon signup. This issue was fixed upstream in https://github.com/StanfordSpezi/SpeziFirebase/pull/36.


## :gear: Release Notes 
* Fixed an issue where the Account Setup sheet wouldn't disappear after a successful login.
* Fixed an issue where the name details wouldn't be saved after a successful signup.


## :books: Documentation
--


## :white_check_mark: Testing
UI test was added to verify the setup sheet is dismissed after login.


### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).
