### PR TITLE
Integrate BP7000 and EVOLV Blood Pressure Cuffs

### DIFF
--- a/ENGAGEHF.xcodeproj/project.pbxproj
+++ b/ENGAGEHF.xcodeproj/project.pbxproj
@@ -1341,8 +1341,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/StanfordSpezi/SpeziDevices.git";
 			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 1.0.0;
+				branch = "feature/bluetooth-update";
+				kind = branch;
 			};
 		};
 		A9A0BF012C13121D00B8F3F3 /* XCRemoteSwiftPackageReference "SpeziNetworking" */ = {

--- a/ENGAGEHF.xcodeproj/project.pbxproj
+++ b/ENGAGEHF.xcodeproj/project.pbxproj
@@ -1341,8 +1341,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/StanfordSpezi/SpeziDevices.git";
 			requirement = {
-				branch = "feature/bluetooth-update";
-				kind = branch;
+				kind = upToNextMajorVersion;
+				minimumVersion = 1.1.0;
 			};
 		};
 		A9A0BF012C13121D00B8F3F3 /* XCRemoteSwiftPackageReference "SpeziNetworking" */ = {

--- a/ENGAGEHF.xcodeproj/project.pbxproj
+++ b/ENGAGEHF.xcodeproj/project.pbxproj
@@ -1310,7 +1310,7 @@
 			repositoryURL = "https://github.com/StanfordSpezi/SpeziBluetooth.git";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 2.0.0;
+				minimumVersion = "3.0.0-beta.1";
 			};
 		};
 		5661551B2AB8384200209B80 /* XCRemoteSwiftPackageReference "swift-package-list" */ = {

--- a/ENGAGEHF.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ENGAGEHF.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -60,8 +60,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/firebase/firebase-ios-sdk.git",
       "state" : {
-        "revision" : "e57841b296d04370ea23580f908881b0ccab17b9",
-        "version" : "10.28.1"
+        "revision" : "eca84fd638116dd6adb633b5a3f31cc7befcbb7d",
+        "version" : "10.29.0"
       }
     },
     {
@@ -114,8 +114,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/StanfordBDHG/HealthKitOnFHIR.git",
       "state" : {
-        "revision" : "418929f315f37e6d9c8f30f40030bc65b9cc47c9",
-        "version" : "0.2.8"
+        "revision" : "b0cfe35a2263a517b22196b559d2dd1d1e2afcd9",
+        "version" : "0.2.9"
       }
     },
     {
@@ -186,8 +186,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/StanfordSpezi/Spezi",
       "state" : {
-        "revision" : "5ada3f3a18c86a658d140c6f4c45ca2e9d5e61ce",
-        "version" : "1.4.0"
+        "revision" : "afdf500a23cc7eabcb759044f5524514e91a99dc",
+        "version" : "1.5.1"
       }
     },
     {
@@ -202,10 +202,10 @@
     {
       "identity" : "spezibluetooth",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/StanfordSpezi/SpeziBluetooth.git",
+      "location" : "https://github.com/StanfordSpezi/SpeziBluetooth",
       "state" : {
-        "revision" : "6b88cae1ea9a18ec875dcc8fae80cbeb291133f0",
-        "version" : "2.0.1"
+        "branch" : "feature/strict-concurrency",
+        "revision" : "2c1946127fe5ae295ad4b62893b8a6242bc112f0"
       }
     },
     {
@@ -222,8 +222,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/StanfordSpezi/SpeziDevices.git",
       "state" : {
-        "revision" : "6b5e24f9983ae0ffccd57d078edb3981400af721",
-        "version" : "1.0.0"
+        "branch" : "feature/bluetooth-update",
+        "revision" : "49df573893f70076bd2d221b15ae29b7988dc40c"
       }
     },
     {
@@ -231,8 +231,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/StanfordSpezi/SpeziFirebase.git",
       "state" : {
-        "revision" : "00ff0db12bf72ba39354e263d8f916ae8392368b",
-        "version" : "1.1.2"
+        "revision" : "67981d0f0b4f0bb70f120f9b5304e7c0b08e5717",
+        "version" : "1.1.3"
       }
     },
     {
@@ -240,8 +240,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/StanfordSpezi/SpeziFoundation",
       "state" : {
-        "revision" : "3326feab3dac120c16af63243615592990d33516",
-        "version" : "1.1.2"
+        "revision" : "4781d96a09587f3d47ac3f3e71d197149b288146",
+        "version" : "1.1.3"
       }
     },
     {
@@ -330,8 +330,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-collections.git",
       "state" : {
-        "revision" : "ee97538f5b81ae89698fd95938896dec5217b148",
-        "version" : "1.1.1"
+        "revision" : "3d2dc41a01f9e49d84f0a3925fb858bed64f702d",
+        "version" : "1.1.2"
       }
     },
     {
@@ -357,8 +357,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-protobuf.git",
       "state" : {
-        "revision" : "9f0c76544701845ad98716f3f6a774a892152bcb",
-        "version" : "1.26.0"
+        "revision" : "d57a5aecf24a25b32ec4a74be2f5d0a995a47c4b",
+        "version" : "1.27.0"
       }
     },
     {
@@ -429,8 +429,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/StanfordBDHG/XCTRuntimeAssertions",
       "state" : {
-        "revision" : "51da3403f128b120705571ce61e0fe190f8889e6",
-        "version" : "1.0.1"
+        "revision" : "7ce28015c0bee62b523a860e343e3d6b7ec40fda",
+        "version" : "1.1.1"
       }
     },
     {
@@ -438,8 +438,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/jpsim/Yams.git",
       "state" : {
-        "revision" : "9234124cff5e22e178988c18d8b95a8ae8007f76",
-        "version" : "5.1.2"
+        "revision" : "3036ba9d69cf1fd04d433527bc339dc0dc75433d",
+        "version" : "5.1.3"
       }
     }
   ],

--- a/ENGAGEHF.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ENGAGEHF.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -205,7 +205,7 @@
       "location" : "https://github.com/StanfordSpezi/SpeziBluetooth",
       "state" : {
         "branch" : "feature/strict-concurrency",
-        "revision" : "2c1946127fe5ae295ad4b62893b8a6242bc112f0"
+        "revision" : "23c9c5afdd2c61ba68c6e2c7a52c874dc21c4496"
       }
     },
     {
@@ -223,7 +223,7 @@
       "location" : "https://github.com/StanfordSpezi/SpeziDevices.git",
       "state" : {
         "branch" : "feature/bluetooth-update",
-        "revision" : "49df573893f70076bd2d221b15ae29b7988dc40c"
+        "revision" : "75bafd9e04ea0f8be2d869d47043ced0cd0f3853"
       }
     },
     {

--- a/ENGAGEHF.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ENGAGEHF.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -204,8 +204,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/StanfordSpezi/SpeziBluetooth",
       "state" : {
-        "revision" : "fe7cbfd5eb69464e2736ea6b6118c7af15f7289c",
-        "version" : "2.0.2"
+        "revision" : "387ed5d79be6ae990f714b648ed6a157c30d5b4d",
+        "version" : "3.0.0-beta.1"
       }
     },
     {
@@ -222,8 +222,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/StanfordSpezi/SpeziDevices.git",
       "state" : {
-        "revision" : "641db1798c0cf3067840bb9283b764ebb5ee6781",
-        "version" : "1.0.1"
+        "revision" : "ac008a4d6fcbd3ad6e10fcf9dc4954df94251bb7",
+        "version" : "1.1.0"
       }
     },
     {

--- a/ENGAGEHF.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ENGAGEHF.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -204,8 +204,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/StanfordSpezi/SpeziBluetooth",
       "state" : {
-        "branch" : "feature/strict-concurrency",
-        "revision" : "23c9c5afdd2c61ba68c6e2c7a52c874dc21c4496"
+        "revision" : "fe7cbfd5eb69464e2736ea6b6118c7af15f7289c",
+        "version" : "2.0.2"
       }
     },
     {
@@ -222,8 +222,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/StanfordSpezi/SpeziDevices.git",
       "state" : {
-        "branch" : "feature/bluetooth-update",
-        "revision" : "75bafd9e04ea0f8be2d869d47043ced0cd0f3853"
+        "revision" : "641db1798c0cf3067840bb9283b764ebb5ee6781",
+        "version" : "1.0.1"
       }
     },
     {

--- a/ENGAGEHF/ENGAGEHFDelegate.swift
+++ b/ENGAGEHF/ENGAGEHFDelegate.swift
@@ -50,8 +50,8 @@ class ENGAGEHFDelegate: SpeziAppDelegate {
             }
 
             Bluetooth {
-                Discover(OmronWeightScale.self, by: .accessory(manufacturer: .omronHealthcareCoLtd, advertising: WeightScaleService.self))
-                Discover(OmronBloodPressureCuff.self, by: .accessory(manufacturer: .omronHealthcareCoLtd, advertising: BloodPressureService.self))
+                Discover(OmronWeightScale.self, by: .advertisedService(WeightScaleService.self))
+                Discover(OmronBloodPressureCuff.self, by: .advertisedService(BloodPressureService.self))
             }
             
             PairedDevices()

--- a/ENGAGEHF/Home.swift
+++ b/ENGAGEHF/Home.swift
@@ -63,7 +63,7 @@ struct HomeView: View {
                 DevicesView(appName: ENGAGEHF.appName ?? "ENGAGE") {
                     Text("Hold down the Bluetooth button for 3 seconds to put the device into pairing mode.")
                 }
-                    .environment(\.advertisementStaleInterval, 15)
+                    .bluetoothScanningOptions(advertisementStaleInterval: 15)
             }
                 .tag(Tabs.devices)
                 .tabItem {

--- a/ENGAGEHF/Resources/Localizable.xcstrings
+++ b/ENGAGEHF/Resources/Localizable.xcstrings
@@ -1,9 +1,6 @@
 {
   "sourceLanguage" : "en",
   "strings" : {
-    "%@" : {
-
-    },
     "%@ Date: %@" : {
       "localizations" : {
         "en" : {
@@ -85,12 +82,6 @@
         }
       }
     },
-    "Add Mock" : {
-
-    },
-    "Add mock notification" : {
-
-    },
     "An error occurred: %@" : {
       "comment" : "General Error"
     },
@@ -127,9 +118,6 @@
           }
         }
       }
-    },
-    "Content ..." : {
-
     },
     "Devices" : {
 
@@ -344,12 +332,6 @@
           }
         }
       }
-    },
-    "List With Sections" : {
-
-    },
-    "List Without Sections" : {
-
     },
     "No recent %@ measurement available" : {
 


### PR DESCRIPTION
# Integrate BP7000 and EVOLV Blood Pressure Cuffs

## :recycle: Current situation & Problem
This PR integrates the changes from https://github.com/StanfordSpezi/SpeziDevices/pull/7 adding support for BP7000 and EVOLV blood pressure cuffs. Devices might need to be connected once to refresh their icon assets due to underlying changes in SpeziDevices on how assets are derived from the PairedDeviceInfo storage.

## :gear: Release Notes 
* Integrated BP7000 and EVOLV BPs


## :books: Documentation
--


## :white_check_mark: Testing
Manual testing using the BP7000.

### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).
