### PR TITLE
Fix issue where same type devices couldn't connect at the same time

### DIFF
--- a/ENGAGEHF.xcodeproj/project.pbxproj
+++ b/ENGAGEHF.xcodeproj/project.pbxproj
@@ -1536,7 +1536,7 @@
 			repositoryURL = "https://github.com/StanfordSpezi/Spezi";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 1.4.0;
+				minimumVersion = 1.6.0;
 			};
 		};
 		2F66D20D2BB723180010D555 /* XCRemoteSwiftPackageReference "SwiftLint" */ = {

--- a/ENGAGEHF.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ENGAGEHF.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -186,8 +186,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/StanfordSpezi/Spezi",
       "state" : {
-        "revision" : "afdf500a23cc7eabcb759044f5524514e91a99dc",
-        "version" : "1.5.1"
+        "revision" : "d87e3d8104a0732c0e294e9ae6354db4a7058800",
+        "version" : "1.6.0"
       }
     },
     {
@@ -202,7 +202,7 @@
     {
       "identity" : "spezibluetooth",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/StanfordSpezi/SpeziBluetooth.git",
+      "location" : "https://github.com/StanfordSpezi/SpeziBluetooth",
       "state" : {
         "revision" : "387ed5d79be6ae990f714b648ed6a157c30d5b4d",
         "version" : "3.0.0-beta.1"


### PR DESCRIPTION
# Fix issue where same type devices couldn't connect at the same time

## :recycle: Current situation & Problem
This PR resolves an issue where multiple blood pressure cuffs or multiple weight scales couldn't be connected to the app at the same time. This was resolved by updating the Spezi dependencies. See https://github.com/StanfordSpezi/SpeziBluetooth/issues/44.


## :gear: Release Notes 
* Fixed crash when trying to pair two devices of the same kind.


## :books: Documentation
--


## :white_check_mark: Testing
Manually verified.

### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).
