### PR TITLE
Fix state update bug

### DIFF
--- a/ENGAGEHF.xcodeproj/xcshareddata/xcschemes/ENGAGEHF.xcscheme
+++ b/ENGAGEHF.xcodeproj/xcshareddata/xcschemes/ENGAGEHF.xcscheme
@@ -87,7 +87,7 @@
          </CommandLineArgument>
          <CommandLineArgument
             argument = "--setupMockVitals"
-            isEnabled = "YES">
+            isEnabled = "NO">
          </CommandLineArgument>
          <CommandLineArgument
             argument = "--assumeOnboardingComplete"

--- a/ENGAGEHF/HeartHealth/Shared/GraphSection/VitalsGraph+ViewModel.swift
+++ b/ENGAGEHF/HeartHealth/Shared/GraphSection/VitalsGraph+ViewModel.swift
@@ -148,7 +148,7 @@ extension VitalsGraph {
         }
         
         private func getInterval(date: Date, unit: Calendar.Component) -> DateInterval? {
-            calendar.dateInterval(of: dateUnit, for: date)
+            calendar.dateInterval(of: unit, for: date)
         }
     }
 }

--- a/ENGAGEHF/HeartHealth/Shared/GraphSection/VitalsGraph.swift
+++ b/ENGAGEHF/HeartHealth/Shared/GraphSection/VitalsGraph.swift
@@ -29,13 +29,8 @@ struct VitalsGraph: View {
             // Overlay for tracking gestures
             .modifier(GestureOverlay(viewModel: viewModel))
             // State change modifiers to listen for updates to the environment and handle errors
-            .onChange(of: options) {
-                print("Options changed")
-                viewModel.processData(data, options: options)
-            }
-            .task {
-                viewModel.processData(data, options: options)
-            }
+            .onChange(of: options) { viewModel.processData(data, options: options) }
+            .task { viewModel.processData(data, options: options) }
             .viewStateAlert(state: $viewModel.viewState)
     }
     

--- a/ENGAGEHF/HeartHealth/Shared/GraphSection/VitalsGraph.swift
+++ b/ENGAGEHF/HeartHealth/Shared/GraphSection/VitalsGraph.swift
@@ -29,13 +29,11 @@ struct VitalsGraph: View {
             // Overlay for tracking gestures
             .modifier(GestureOverlay(viewModel: viewModel))
             // State change modifiers to listen for updates to the environment and handle errors
-            .onChange(of: data) {
-                viewModel.processData(data, options: options)
-            }
             .onChange(of: options) {
+                print("Options changed")
                 viewModel.processData(data, options: options)
             }
-            .onAppear {
+            .task {
                 viewModel.processData(data, options: options)
             }
             .viewStateAlert(state: $viewModel.viewState)

--- a/ENGAGEHF/HeartHealth/Vitals/HKSampleGraph/HKSampleGraph.swift
+++ b/ENGAGEHF/HeartHealth/Vitals/HKSampleGraph/HKSampleGraph.swift
@@ -30,7 +30,7 @@ struct HKSampleGraph: View {
             )
         )
             .onChange(of: data) { viewModel.processData(data: data) }
-            .onAppear { viewModel.processData(data: data) }
+            .task { viewModel.processData(data: data) }
             .viewStateAlert(state: $viewModel.viewState)
     }
 }

--- a/ENGAGEHF/Resources/Localizable.xcstrings
+++ b/ENGAGEHF/Resources/Localizable.xcstrings
@@ -648,7 +648,7 @@
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "No body weight measurements available. Please connect your Weight Wcale device to begin recording."
+            "value" : "No body weight measurements available. Please connect your Weight Scale device to begin recording."
           }
         }
       }


### PR DESCRIPTION
#49

# Fix vitals graphs not updating on change of date resolution

## :recycle: Current situation & Problem
Currently, we are seeing a bug where the vitals graphs do not update correctly when we change the date resolution (see issue #49).


## :gear: Release Notes 
- The problem was that a helper function in VitalsGraph.ViewModel (getInterval) that is called to group measurements by date as part of the aggregating process used self.dateUnit instead of a passed parameter unit:

Before:
```swift
private func getInterval(date: Date, unit: Calendar.Component) -> DateInterval? {
    calendar.dateInterval(of: dateUnit, for: date)
}
``` 
After:
```swift
private func getInterval(date: Date, unit: Calendar.Component) -> DateInterval? {
    calendar.dateInterval(of: unit, for: date)
}
``` 
This caused the data to be aggregated according to the ViewModel's stored parameter dateUnit, which is only updated after the data has been processed with the new, passed parameter.

Additional Changes:
- Now use .task instead of .onAppear to process data in HKSampleGraph and VitalsGraph to reduce unnecessary data processing.
- Removed the .onChange(of: data) modifier in VitalsGraph to reduce unnecessary data processing

## :books: Documentation
NA


## :white_check_mark: Testing
Unit tests and UI tests still target the graphs, and user testing will cover the more nuanced interactions such as gestures to interact with the graphs.

### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [X] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).
