### PR TITLE
enhancement/maintenance

### DIFF
--- a/ENGAGEHF.xcodeproj/project.pbxproj
+++ b/ENGAGEHF.xcodeproj/project.pbxproj
@@ -160,6 +160,7 @@
 		4DDFC78A2BFC1312002B07A1 /* MessageRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DDFC7892BFC1312002B07A1 /* MessageRow.swift */; };
 		4DE8B8D12C614377006E3E63 /* NavigationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DE8B8D02C614377006E3E63 /* NavigationManager.swift */; };
 		4DE8B8DB2C61A329006E3E63 /* ScrollableText.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DE8B8DA2C61A328006E3E63 /* ScrollableText.swift */; };
+		4DF36FF52C667D39004D737A /* AxisModifiers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DF36FF42C667D39004D737A /* AxisModifiers.swift */; };
 		4DF506192C2E1AAE003E7EFB /* SymptomsType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DF506182C2E1AAD003E7EFB /* SymptomsType.swift */; };
 		4DF506212C2E1C89003E7EFB /* SymptomScore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DF506202C2E1C89003E7EFB /* SymptomScore.swift */; };
 		4DF506282C2F2598003E7EFB /* VitalsContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DF506272C2F2598003E7EFB /* VitalsContentView.swift */; };
@@ -342,6 +343,7 @@
 		4DDFC7892BFC1312002B07A1 /* MessageRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageRow.swift; sourceTree = "<group>"; };
 		4DE8B8D02C614377006E3E63 /* NavigationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationManager.swift; sourceTree = "<group>"; };
 		4DE8B8DA2C61A328006E3E63 /* ScrollableText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScrollableText.swift; sourceTree = "<group>"; };
+		4DF36FF42C667D39004D737A /* AxisModifiers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AxisModifiers.swift; sourceTree = "<group>"; };
 		4DF506182C2E1AAD003E7EFB /* SymptomsType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SymptomsType.swift; sourceTree = "<group>"; };
 		4DF506202C2E1C89003E7EFB /* SymptomScore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SymptomScore.swift; sourceTree = "<group>"; };
 		4DF506272C2F2598003E7EFB /* VitalsContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VitalsContentView.swift; sourceTree = "<group>"; };
@@ -722,6 +724,7 @@
 				4DF506292C2F260E003E7EFB /* SymptomsContentView.swift */,
 				4D92B9F72C3C901500ABCED7 /* SymptomsGraphSection.swift */,
 				4DF5062E2C2F2B00003E7EFB /* SymptomsPicker.swift */,
+				4DF36FF42C667D39004D737A /* AxisModifiers.swift */,
 			);
 			path = Symptoms;
 			sourceTree = "<group>";
@@ -1218,6 +1221,7 @@
 				4DF506282C2F2598003E7EFB /* VitalsContentView.swift in Sources */,
 				4D40728F2C483A5C007C5621 /* VitalsGraph+GestureOverlay.swift in Sources */,
 				4D92B9F82C3C901500ABCED7 /* SymptomsGraphSection.swift in Sources */,
+				4DF36FF52C667D39004D737A /* AxisModifiers.swift in Sources */,
 				2FF53D8D2A8729D600042B76 /* ENGAGEHFStandard.swift in Sources */,
 				4DDFC78A2BFC1312002B07A1 /* MessageRow.swift in Sources */,
 				4D8402722C4EC0D400817495 /* MeasurementListHeader.swift in Sources */,

--- a/ENGAGEHF.xcodeproj/xcshareddata/xcschemes/ENGAGEHF.xcscheme
+++ b/ENGAGEHF.xcodeproj/xcshareddata/xcschemes/ENGAGEHF.xcscheme
@@ -57,7 +57,7 @@
       </Testables>
    </TestAction>
    <LaunchAction
-      buildConfiguration = "Debug"
+      buildConfiguration = "Release"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"

--- a/ENGAGEHF.xcodeproj/xcshareddata/xcschemes/ENGAGEHF.xcscheme
+++ b/ENGAGEHF.xcodeproj/xcshareddata/xcschemes/ENGAGEHF.xcscheme
@@ -57,7 +57,7 @@
       </Testables>
    </TestAction>
    <LaunchAction
-      buildConfiguration = "Release"
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"

--- a/ENGAGEHF.xcodeproj/xcshareddata/xcschemes/ENGAGEHF.xcscheme
+++ b/ENGAGEHF.xcodeproj/xcshareddata/xcschemes/ENGAGEHF.xcscheme
@@ -99,7 +99,7 @@
          </CommandLineArgument>
          <CommandLineArgument
             argument = "--assumeOnboardingComplete"
-            isEnabled = "NO">
+            isEnabled = "YES">
          </CommandLineArgument>
          <CommandLineArgument
             argument = "--setupTestEnvironment"

--- a/ENGAGEHF/Dashboard/Messages/MessagesSection.swift
+++ b/ENGAGEHF/Dashboard/Messages/MessagesSection.swift
@@ -52,6 +52,7 @@ struct MessagesSection: View {
 }
 
 
+#if DEBUG
 #Preview {
     struct MessagesSectionPreviewWrapper: View {
         @Environment(MessageManager.self) private var messageManager
@@ -80,3 +81,4 @@ struct MessagesSection: View {
             MessageManager()
         }
 }
+#endif

--- a/ENGAGEHF/HeartHealth/SelectionTypes/SymptomsType.swift
+++ b/ENGAGEHF/HeartHealth/SelectionTypes/SymptomsType.swift
@@ -66,13 +66,13 @@ enum SymptomsType: String, CaseIterable, Identifiable, CustomStringConvertible, 
     }
     
     /// The path to access the parameter in SymptomScore that corresponds to the Type described by an instance of this enum
-    var symptomScoreKeyMap: KeyPath<SymptomScore, Double> {
+    var symptomScoreKeyMap: KeyPath<SymptomScore, Double?> {
         switch self {
         case .overall: \.overallScore
         case .physical: \.physicalLimitsScore
         case .social: \.socialLimitsScore
         case .quality: \.qualityOfLifeScore
-        case .specific: \.specificSymptomsScore
+        case .specific: \.symptomFrequencyScore
         case .dizziness: \.dizzinessScore
         }
     }

--- a/ENGAGEHF/HeartHealth/Shared/ListSection/MeasurementListRow.swift
+++ b/ENGAGEHF/HeartHealth/Shared/ListSection/MeasurementListRow.swift
@@ -10,8 +10,8 @@ import SwiftUI
 
 
 struct MeasurementListRow: View {
-    let displayQuantity: String
-    let displayUnit: String
+    let displayQuantity: String?
+    let displayUnit: String?
     let displayDate: String
     let type: String
     

--- a/ENGAGEHF/HeartHealth/Shared/ListSection/MeasurementListSection.swift
+++ b/ENGAGEHF/HeartHealth/Shared/ListSection/MeasurementListSection.swift
@@ -12,7 +12,7 @@ import SwiftUI
 
 struct MeasurementListSection: View {
     var data: [VitalListMeasurement]
-    var units: String
+    var units: String?
     var type: GraphSelection
     
     @Environment(VitalsManager.self) private var vitalsManager

--- a/ENGAGEHF/HeartHealth/Shared/ListSection/VitalListMeasurement.swift
+++ b/ENGAGEHF/HeartHealth/Shared/ListSection/VitalListMeasurement.swift
@@ -13,6 +13,6 @@ import Foundation
 /// Contains all the necessary information for display in the VitalsList in the All Data section
 struct VitalListMeasurement: Identifiable, Hashable {
     var id: String?
-    var value: String
+    var value: String?
     var date: Date
 }

--- a/ENGAGEHF/HeartHealth/Symptoms/AxisModifiers.swift
+++ b/ENGAGEHF/HeartHealth/Symptoms/AxisModifiers.swift
@@ -1,0 +1,41 @@
+//
+// This source file is part of the ENGAGE-HF project based on the Stanford Spezi Template Application project
+//
+// SPDX-FileCopyrightText: 2023 Stanford University
+//
+// SPDX-License-Identifier: MIT
+//
+
+import Charts
+import SwiftUI
+
+
+struct DizzinessYAxisModifier: ViewModifier {
+    func body(content: Content) -> some View {
+        content
+            .chartYScale(domain: 0...5)
+            .chartYAxis {
+                AxisMarks(values: .automatic(desiredCount: 5))
+            }
+    }
+}
+
+struct PercentageYAxisModifier: ViewModifier {
+    func body(content: Content) -> some View {
+        content
+            .chartYScale(domain: 0...100)
+            .chartYAxis {
+                AxisMarks(
+                    values: [0, 50, 100]
+                ) {
+                    AxisValueLabel(format: Decimal.FormatStyle.Percent.percent.scale(1))
+                }
+                
+                AxisMarks(
+                    values: [0, 25, 50, 75, 100]
+                ) {
+                    AxisGridLine()
+                }
+            }
+    }
+}

--- a/ENGAGEHF/HeartHealth/Symptoms/SymptomsContentView.swift
+++ b/ENGAGEHF/HeartHealth/Symptoms/SymptomsContentView.swift
@@ -19,7 +19,9 @@ struct SymptomsContentView: View {
             .map { score in
                 VitalListMeasurement(
                     id: score.id,
-                    value: String(format: "%.1f", score[keyPath: symptomsType.symptomScoreKeyMap]),
+                    // TODO: If this is dizziness, format it as an integer and have no "%" unit in list or graph
+                    // TODO: Otherwise, keep the percentage and double formatting
+                    value: score[keyPath: symptomsType.symptomScoreKeyMap].map { String(format: "%.1f", $0) },
                     date: score.date
                 )
             }
@@ -37,7 +39,7 @@ struct SymptomsContentView: View {
         )
         MeasurementListSection(
             data: listDisplayData,
-            units: "%",
+            units: nil,
             type: .symptoms
         )
             .deleteDisabled(true)

--- a/ENGAGEHF/HeartHealth/Symptoms/SymptomsContentView.swift
+++ b/ENGAGEHF/HeartHealth/Symptoms/SymptomsContentView.swift
@@ -19,9 +19,9 @@ struct SymptomsContentView: View {
             .map { score in
                 VitalListMeasurement(
                     id: score.id,
-                    // TODO: If this is dizziness, format it as an integer and have no "%" unit in list or graph
-                    // TODO: Otherwise, keep the percentage and double formatting
-                    value: score[keyPath: symptomsType.symptomScoreKeyMap].map { String(format: "%.1f", $0) },
+                    value: score[keyPath: symptomsType.symptomScoreKeyMap].map {
+                        $0.asString(minimumFractionDigits: 0, maximumFractionDigits: 1)
+                    },
                     date: score.date
                 )
             }
@@ -39,7 +39,7 @@ struct SymptomsContentView: View {
         )
         MeasurementListSection(
             data: listDisplayData,
-            units: nil,
+            units: symptomsType == .dizziness ? nil : "%",
             type: .symptoms
         )
             .deleteDisabled(true)

--- a/ENGAGEHF/HeartHealth/Symptoms/SymptomsGraphSection.swift
+++ b/ENGAGEHF/HeartHealth/Symptoms/SymptomsGraphSection.swift
@@ -43,9 +43,10 @@ struct SymptomsGraphSection: View {
         VitalsGraphOptions(
             dateRange: resolution.getDateRange(endDate: .now),
             granularity: .day,
-            localizedUnitString: "%",
+            localizedUnitString: symptomsType == .dizziness ? "" : "%",
             selectionFormatter: { selected in
-                String(format: "%.1f", selected.first(where: { $0.0 == KnownVitalsSeries.symptomScore.rawValue })?.1 ?? "---")
+                let matchingSeriesValue = selected.first(where: { $0.0 == KnownVitalsSeries.symptomScore.rawValue })?.1
+                return matchingSeriesValue?.asString(minimumFractionDigits: 0, maximumFractionDigits: 1) ?? "---"
             }
         )
     }

--- a/ENGAGEHF/HeartHealth/Vitals/VitalsContentView.swift
+++ b/ENGAGEHF/HeartHealth/Vitals/VitalsContentView.swift
@@ -49,7 +49,7 @@ struct VitalsContentView: View {
         return data
             .map { sample in
                 VitalListMeasurement(
-                    id: sample.externalUUID?.uuidString,
+                    id: sample.externalID,
                     value: getDisplayQuantity(sample: sample, type: vital),
                     date: sample.startDate
                 )

--- a/ENGAGEHF/Medications/MedicationDetails.swift
+++ b/ENGAGEHF/Medications/MedicationDetails.swift
@@ -10,7 +10,7 @@ import FirebaseFirestore
 import Foundation
 
 
-enum MedicationRecommendationType: String, Codable, Comparable {
+enum MedicationRecommendationType: String, Decodable, Comparable {
     case targetDoseReached
     case personalTargetDoseReached
     case improvementAvailable
@@ -44,7 +44,7 @@ enum MedicationRecommendationType: String, Codable, Comparable {
 
 /// A daily medication schedule. Includes current, minimum, and target schedules.
 /// Example: 20.0 mg twice daily would have dose=20.0 and timesDaily=2.
-struct DoseSchedule: Hashable, Codable {
+struct DoseSchedule: Hashable, Decodable {
     let frequency: Double
     let quantity: [Double]
     
@@ -55,7 +55,7 @@ struct DoseSchedule: Hashable, Codable {
 
 /// A collection containing details of a patients dose for a single medication.
 /// Describes the dosage in terms of total medication across all ingredients.
-struct DosageInformation: Codable {
+struct DosageInformation: Decodable {
     let currentSchedule: [DoseSchedule]
     let minimumSchedule: [DoseSchedule]
     let targetSchedule: [DoseSchedule]
@@ -77,7 +77,7 @@ struct DosageInformation: Codable {
 
 
 /// Wrapper for decoding medication details from firestore.
-struct MedicationDetailsWrapper: Codable {
+struct MedicationDetailsWrapper: Decodable {
     @DocumentID private var id: String?
     
     private let displayInformation: MedicationDetails
@@ -98,18 +98,20 @@ struct MedicationDetails: Identifiable {
     let title: String
     let subtitle: String
     let description: String
+    let videoPath: String?
     let type: MedicationRecommendationType
     let dosageInformation: DosageInformation
 }
 
 
-extension MedicationDetails: Codable {
+extension MedicationDetails: Decodable {
     private enum CodingKeys: CodingKey {
         case title
         case subtitle
         case description
         case type
         case dosageInformation
+        case videoPath
     }
     
     
@@ -119,17 +121,8 @@ extension MedicationDetails: Codable {
         self.title = try container.decodeLocalizedString(forKey: .title)
         self.subtitle = try container.decodeLocalizedString(forKey: .subtitle)
         self.description = try container.decodeLocalizedString(forKey: .description)
+        self.videoPath = try container.decodeIfPresent(String.self, forKey: .videoPath)
         self.type = try container.decode(MedicationRecommendationType.self, forKey: .type)
         self.dosageInformation = try container.decode(DosageInformation.self, forKey: .dosageInformation)
-    }
-    
-    func encode(to encoder: any Encoder) throws {
-        var container = encoder.container(keyedBy: CodingKeys.self)
-        
-        try container.encode(self.title, forKey: .title)
-        try container.encode(self.subtitle, forKey: .subtitle)
-        try container.encode(self.description, forKey: .description)
-        try container.encode(self.type, forKey: .type)
-        try container.encode(self.dosageInformation, forKey: .dosageInformation)
     }
 }

--- a/ENGAGEHF/Medications/MedicationDetails.swift
+++ b/ENGAGEHF/Medications/MedicationDetails.swift
@@ -92,7 +92,7 @@ struct MedicationDetailsWrapper: Codable {
 
 
 /// A medication that the patient is either currently taking or which is recommended for the patient to start.
-struct MedicationDetails: Identifiable, Codable {
+struct MedicationDetails: Identifiable {
     var id: String?
     
     let title: String
@@ -100,4 +100,36 @@ struct MedicationDetails: Identifiable, Codable {
     let description: String
     let type: MedicationRecommendationType
     let dosageInformation: DosageInformation
+}
+
+
+extension MedicationDetails: Codable {
+    private enum CodingKeys: CodingKey {
+        case title
+        case subtitle
+        case description
+        case type
+        case dosageInformation
+    }
+    
+    
+    init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        
+        self.title = try container.decodeLocalizedString(forKey: .title)
+        self.subtitle = try container.decodeLocalizedString(forKey: .subtitle)
+        self.description = try container.decodeLocalizedString(forKey: .description)
+        self.type = try container.decode(MedicationRecommendationType.self, forKey: .type)
+        self.dosageInformation = try container.decode(DosageInformation.self, forKey: .dosageInformation)
+    }
+    
+    func encode(to encoder: any Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        
+        try container.encode(self.title, forKey: .title)
+        try container.encode(self.subtitle, forKey: .subtitle)
+        try container.encode(self.description, forKey: .description)
+        try container.encode(self.type, forKey: .type)
+        try container.encode(self.dosageInformation, forKey: .dosageInformation)
+    }
 }

--- a/ENGAGEHF/Medications/MedicationsManager.swift
+++ b/ENGAGEHF/Medications/MedicationsManager.swift
@@ -89,6 +89,7 @@ extension MedicationsManager {
                 title: "Lorem",
                 subtitle: "Ipsum",
                 description: "Description ",
+                videoPath: "videoSections/1/videos/2",
                 type: .targetDoseReached,
                 dosageInformation: DosageInformation(
                     currentSchedule: [
@@ -111,6 +112,7 @@ extension MedicationsManager {
                 title: "Lozinopril",
                 subtitle: "Beta Blocker",
                 description: "Long description goes here",
+                videoPath: "videoSections/1/videos/2",
                 type: .improvementAvailable,
                 dosageInformation: DosageInformation(
                     currentSchedule: [
@@ -142,6 +144,7 @@ extension MedicationsManager {
                 title: "Carvedilol",
                 subtitle: "Beta Blocker",
                 description: "Your target does has been reached.",
+                videoPath: "videoSections/1/videos/2",
                 type: .targetDoseReached,
                 dosageInformation: DosageInformation(
                     currentSchedule: [DoseSchedule(frequency: 1, quantity: [200])],
@@ -156,6 +159,7 @@ extension MedicationsManager {
                 title: "Empagliflozin",
                 subtitle: "SGLT2i",
                 description: "You have reached your personal target dose.",
+                videoPath: "videoSections/1/videos/2",
                 type: .personalTargetDoseReached,
                 dosageInformation: DosageInformation(
                     currentSchedule: [DoseSchedule(frequency: 1, quantity: [2.5]), DoseSchedule(frequency: 1, quantity: [5])],
@@ -170,6 +174,7 @@ extension MedicationsManager {
                 title: "Sacubitril-Valsartan",
                 subtitle: "ARNI",
                 description: "You are eligible for a new dosage.",
+                videoPath: "videoSections/1/videos/2",
                 type: .improvementAvailable,
                 dosageInformation: DosageInformation(
                     currentSchedule: [DoseSchedule(frequency: 2, quantity: [24, 26])],
@@ -184,6 +189,7 @@ extension MedicationsManager {
                 title: "Spironolactone",
                 subtitle: "MRA",
                 description: "More vitals data required for recommendations.",
+                videoPath: nil,
                 type: .morePatientObservationsRequired,
                 dosageInformation: DosageInformation(
                     currentSchedule: [DoseSchedule(frequency: 1.5, quantity: [0])],
@@ -198,6 +204,7 @@ extension MedicationsManager {
                 title: "Bisoprolol",
                 subtitle: "Beta Blocker",
                 description: "Not started yet. No action required.",
+                videoPath: "videoSections/1/videos/2",
                 type: .notStarted,
                 dosageInformation: DosageInformation(
                     currentSchedule: [],

--- a/ENGAGEHF/Medications/Views/MedicationsList.swift
+++ b/ENGAGEHF/Medications/Views/MedicationsList.swift
@@ -44,6 +44,7 @@ struct MedicationsList: View {
                 title: "Lozinopril",
                 subtitle: "Beta Blocker",
                 description: "Long description goes here",
+                videoPath: "videoSections/1/videos/2",
                 type: .improvementAvailable,
                 dosageInformation: DosageInformation(
                     currentSchedule: [

--- a/ENGAGEHF/Medications/Views/RowContent/MedicationDescription.swift
+++ b/ENGAGEHF/Medications/Views/RowContent/MedicationDescription.swift
@@ -12,6 +12,7 @@ import SwiftUI
 struct MedicationDescription: View {
     let title: String
     let description: String
+    let videoPath: String?
     
     @Environment(NavigationManager.self) private var navigationManager
     
@@ -24,12 +25,17 @@ struct MedicationDescription: View {
             
             Spacer()
             
-            Image(systemName: "questionmark.circle")
-                .foregroundStyle(.accent)
-                .accessibilityLabel("\(title) More Information")
-                .asButton {
-                    navigationManager.switchHomeTab(to: .education)
-                }
+            let action = MessageAction(from: videoPath)
+            if action != .unknown {
+                Image(systemName: "questionmark.circle")
+                    .foregroundStyle(.accent)
+                    .accessibilityLabel("\(title) More Information")
+                    .asButton {
+                        Task {
+                            await navigationManager.execute(action)
+                        }
+                    }
+            }
         }
     }
 }
@@ -38,6 +44,7 @@ struct MedicationDescription: View {
 #Preview {
     MedicationDescription(
         title: "Carvedilol",
-        description: "Target dose reached. No action Required."
+        description: "Target dose reached. No action Required.",
+        videoPath: "videoSections/1/videos/2"
     )
 }

--- a/ENGAGEHF/Medications/Views/RowContent/MedicationRowContent.swift
+++ b/ENGAGEHF/Medications/Views/RowContent/MedicationRowContent.swift
@@ -15,7 +15,11 @@ struct MedicationRowContent: View {
     
     var body: some View {
         VStack(alignment: .leading) {
-            MedicationDescription(title: medication.title, description: medication.description)
+            MedicationDescription(
+                title: medication.title,
+                description: medication.description,
+                videoPath: medication.videoPath
+            )
                 .padding(.vertical, 2)
             
             Divider()
@@ -32,6 +36,7 @@ struct MedicationRowContent: View {
             title: "Lisinopril",
             subtitle: "Beta Blockers",
             description: "Description of the recommendation",
+            videoPath: "videoSections/1/videos/2",
             type: .targetDoseReached,
             dosageInformation: DosageInformation(
                 currentSchedule: [

--- a/ENGAGEHF/Medications/Views/RowLabel/RecommendationSummary.swift
+++ b/ENGAGEHF/Medications/Views/RowLabel/RecommendationSummary.swift
@@ -35,6 +35,7 @@ struct RecommendationSummary: View {
             title: "Lisinopril",
             subtitle: "Beta Blockers",
             description: "Description of the recommendation",
+            videoPath: "videoSections/1/videos/2",
             type: .targetDoseReached,
             dosageInformation: DosageInformation(
                 currentSchedule: [

--- a/ENGAGEHF/MessageManager/MessageAction.swift
+++ b/ENGAGEHF/MessageManager/MessageAction.swift
@@ -47,7 +47,7 @@ extension MessageAction {
     }
     
     
-    init(from actionString: String?) throws {
+    init(from actionString: String?) {
         guard let actionString else {
             self = .unknown
             return

--- a/ENGAGEHF/MessageManager/MessageManager.swift
+++ b/ENGAGEHF/MessageManager/MessageManager.swift
@@ -64,6 +64,7 @@ final class MessageManager: Module, EnvironmentAccessible, DefaultInitializable 
         
         // Set a snapshot listener on the query for valid notifications
         self.snapshotListener = messagesCollectionReference
+            .whereField("completionDate", isEqualTo: NSNull())
             .addSnapshotListener { querySnapshot, error in
                 self.logger.debug("Fetching most recent messages...")
                 

--- a/ENGAGEHF/MessageManager/MessageManager.swift
+++ b/ENGAGEHF/MessageManager/MessageManager.swift
@@ -82,9 +82,6 @@ final class MessageManager: Module, EnvironmentAccessible, DefaultInitializable 
                             return nil
                         }
                     }
-                    // Because the completionDate field is absent before the message is dismissed,
-                    // the only way to filter out dismissed messages is to do so on the client
-                    .filter { $0.completionDate == nil }
                 
                 self.logger.debug("Messages updated.")
             }

--- a/ENGAGEHF/Resources/Localizable.xcstrings
+++ b/ENGAGEHF/Resources/Localizable.xcstrings
@@ -4,9 +4,6 @@
     "" : {
 
     },
-    "%@" : {
-
-    },
     "%@ Date: %@" : {
       "localizations" : {
         "en" : {
@@ -113,15 +110,6 @@
     "Add Measurement: %@" : {
 
     },
-    "Add Medications" : {
-
-    },
-    "Add Mock" : {
-
-    },
-    "Add mock notification" : {
-
-    },
     "All Data" : {
 
     },
@@ -182,9 +170,6 @@
           }
         }
       }
-    },
-    "Content ..." : {
-
     },
     "Current" : {
 
@@ -415,12 +400,6 @@
         }
       }
     },
-    "List With Sections" : {
-
-    },
-    "List Without Sections" : {
-
-    },
     "Medication Label: %@" : {
 
     },
@@ -508,9 +487,6 @@
 
     },
     "Show less" : {
-
-    },
-    "Show Measurements" : {
 
     },
     "Show more" : {
@@ -603,9 +579,6 @@
         }
       }
     },
-    "Tap Here" : {
-
-    },
     "Target" : {
 
     },
@@ -618,13 +591,7 @@
     "Time" : {
 
     },
-    "Trigger Blood Pressure Measurement" : {
-
-    },
     "Trigger Sheet" : {
-
-    },
-    "Trigger Weight Measurement" : {
 
     },
     "Unable to create time interval for date: %@" : {

--- a/ENGAGEHF/ReusableElements/DisplayMeasurement.swift
+++ b/ENGAGEHF/ReusableElements/DisplayMeasurement.swift
@@ -10,21 +10,23 @@ import SwiftUI
 
 
 struct DisplayMeasurement: View {
-    let quantity: String
-    let units: String
+    let quantity: String?
+    let units: String?
     let type: String
     @ScaledMetric var quantityTextSize: CGFloat
     
     
     var body: some View {
         HStack(alignment: .firstTextBaseline, spacing: 4) {
-            Text(quantity)
+            Text(quantity ?? "n/a")
                 .font(.system(size: quantityTextSize, weight: .semibold, design: .rounded))
-                .accessibilityLabel("\(type) Quantity: \(quantity)")
-            Text(units)
-                .font(.title3)
-                .foregroundStyle(Color.secondary)
-                .accessibilityLabel("\(type) Unit: \(units)")
+                .accessibilityLabel("\(type) Quantity: \(quantity ?? "n/a")")
+            if quantity != nil, let units {
+                Text(units)
+                    .font(.title3)
+                    .foregroundStyle(Color.secondary)
+                    .accessibilityLabel("\(type) Unit: \(units)")
+            }
         }
     }
 }

--- a/ENGAGEHF/ReusableElements/DisplayMeasurement.swift
+++ b/ENGAGEHF/ReusableElements/DisplayMeasurement.swift
@@ -18,7 +18,7 @@ struct DisplayMeasurement: View {
     
     var body: some View {
         HStack(alignment: .firstTextBaseline, spacing: 4) {
-            Text(quantity ?? "n/a")
+            Text(quantity ?? "N/A")
                 .font(.system(size: quantityTextSize, weight: .semibold, design: .rounded))
                 .accessibilityLabel("\(type) Quantity: \(quantity ?? "N/A")")
             if quantity != nil, let units {

--- a/ENGAGEHF/ReusableElements/DisplayMeasurement.swift
+++ b/ENGAGEHF/ReusableElements/DisplayMeasurement.swift
@@ -20,7 +20,7 @@ struct DisplayMeasurement: View {
         HStack(alignment: .firstTextBaseline, spacing: 4) {
             Text(quantity ?? "n/a")
                 .font(.system(size: quantityTextSize, weight: .semibold, design: .rounded))
-                .accessibilityLabel("\(type) Quantity: \(quantity ?? "n/a")")
+                .accessibilityLabel("\(type) Quantity: \(quantity ?? "N/A")")
             if quantity != nil, let units {
                 Text(units)
                     .font(.title3)

--- a/ENGAGEHF/VitalsManager/Extensions/HKObject+ExternalUUID.swift
+++ b/ENGAGEHF/VitalsManager/Extensions/HKObject+ExternalUUID.swift
@@ -11,11 +11,7 @@ import HealthKit
 
 
 extension HKObject {
-    var externalUUID: UUID? {
-        guard let string = metadata?[HKMetadataKeyExternalUUID] as? String else {
-            return nil
-        }
-        
-        return UUID(uuidString: string)
+    var externalID: String? {
+        metadata?[HKMetadataKeyExternalUUID] as? String
     }
 }

--- a/ENGAGEHF/VitalsManager/SymptomScore.swift
+++ b/ENGAGEHF/VitalsManager/SymptomScore.swift
@@ -16,10 +16,10 @@ import Foundation
 public struct SymptomScore: Identifiable, Equatable, Codable {
     @DocumentID public var id: String?
     public let date: Date
-    public let overallScore: Double
-    public let physicalLimitsScore: Double
-    public let socialLimitsScore: Double
-    public let qualityOfLifeScore: Double
-    public let specificSymptomsScore: Double
-    public let dizzinessScore: Double
+    public let overallScore: Double?
+    public let physicalLimitsScore: Double?
+    public let socialLimitsScore: Double?
+    public let qualityOfLifeScore: Double?
+    public let symptomFrequencyScore: Double?
+    public let dizzinessScore: Double?
 }

--- a/ENGAGEHF/VitalsManager/VitalsManager.swift
+++ b/ENGAGEHF/VitalsManager/VitalsManager.swift
@@ -365,8 +365,8 @@ extension VitalsManager {
             physicalLimitsScore: Double.random(in: 0...100),
             socialLimitsScore: Double.random(in: 0...100),
             qualityOfLifeScore: Double.random(in: 0...100),
-            specificSymptomsScore: Double.random(in: 0...100),
-            dizzinessScore: Double.random(in: 0...100)
+            symptomFrequencyScore: Double.random(in: 0...100),
+            dizzinessScore: Double.random(in: 0...5)
         )
         
         return dummySymptoms

--- a/ENGAGEHFUITests/MedicationsUITests.swift
+++ b/ENGAGEHFUITests/MedicationsUITests.swift
@@ -39,7 +39,7 @@ final class MedicationsUITests: XCTestCase {
         
         sleep(1)
         
-        XCTAssert(app.staticTexts["Education"].waitForExistence(timeout: 0.5))
+        XCTAssert(app.buttons["Education"].exists)
     }
     
     func testEmptyMedications() throws {


### PR DESCRIPTION
# Bug fixes and minor model changes

## :recycle: Current situation & Problem
As the server implementation progressed, certain elements such as linking medication cards to a specific video became possible. We collected all these small changes into this patch PR.


## :gear: Release Notes 
- Added videoPath to Medication to link directly to relevant video
- Fixed TestFlight deployment bug
- Dizziness Symptom Scores are displayed with Y-axis ranging from 0-5 and with no "%" as units
- Support optional values for Symptom Scores (do not show nil values in graph, but show them as "N/A" in the list section)
- Leverage "null" default value of completionDate field in Message to filter Firestore query for messages that have been dismissed (instead of taking all message from the collection and discarding the dismissed ones on the client)

## :books: Documentation
See inline documentation.


## :white_check_mark: Testing
Tests are updated to reflect the changes, where present.


### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [X] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).
