### PR TITLE
Disable background processing mode

### DIFF
--- a/ENGAGEHF.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ENGAGEHF.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -238,7 +238,7 @@
     {
       "identity" : "spezifoundation",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/StanfordSpezi/SpeziFoundation.git",
+      "location" : "https://github.com/StanfordSpezi/SpeziFoundation",
       "state" : {
         "revision" : "d3a675735c734001e29e51689217d160bde51ce2",
         "version" : "2.0.0-beta.1"

--- a/ENGAGEHF/Managers/VideoManager/VideoManager.swift
+++ b/ENGAGEHF/Managers/VideoManager/VideoManager.swift
@@ -49,6 +49,10 @@ final class VideoManager: Module, EnvironmentAccessible, DefaultInitializable {
                 }
             }
         }
+        
+        Task { @MainActor in
+            videoCollections = await getVideoSections()
+        }
     }
     
     

--- a/ENGAGEHF/Medications/RowContent/DosageGauge/CapsuleStack.swift
+++ b/ENGAGEHF/Medications/RowContent/DosageGauge/CapsuleStack.swift
@@ -10,24 +10,25 @@ import SwiftUI
 
 
 struct CapsuleStack: View {
-    let gaugeWidth: CGFloat
     let gaugeHeight: CGFloat
-    let progressWidth: CGFloat
+    let progress: CGFloat
     
     
     var body: some View {
-        ZStack(alignment: .leading) {
-            Capsule()
-                .frame(height: gaugeHeight)
-                .foregroundStyle(Color(.systemGray6))
-            Capsule()
-                .frame(width: progressWidth, height: gaugeHeight)
-                .foregroundStyle(.accent)
+        GeometryReader { geometry in
+            ZStack(alignment: .leading) {
+                Capsule()
+                    .foregroundStyle(Color(.systemGray6))
+                Capsule()
+                    .frame(width: progress * geometry.size.width)
+                    .foregroundStyle(.accent)
+            }
         }
+            .frame(height: gaugeHeight)
     }
 }
 
 
 #Preview {
-    CapsuleStack(gaugeWidth: 50.0, gaugeHeight: 15, progressWidth: 40)
+    CapsuleStack(gaugeHeight: 15, progress: 0.5)
 }

--- a/ENGAGEHF/Medications/RowContent/DosageGauge/DosageGaugeStyle.swift
+++ b/ENGAGEHF/Medications/RowContent/DosageGauge/DosageGaugeStyle.swift
@@ -30,18 +30,17 @@ struct DosageGaugeStyle: GaugeStyle {
     
     
     func makeBody(configuration: Configuration) -> some View {
-        let progressWidth: CGFloat = gaugeWidth * configuration.value
-        
-        
         VStack {
             configuration.label
             
-            CapsuleStack(gaugeWidth: gaugeWidth, gaugeHeight: gaugeHeight, progressWidth: progressWidth)
+            CapsuleStack(gaugeHeight: gaugeHeight, progress: configuration.value)
                 .readSize(GaugeSizeKey.self) {
                     gaugeWidth = $0.width
                 }
             
             if currentLabelAlignment == .dynamic {
+                let progressWidth: CGFloat = gaugeWidth * configuration.value
+                
                 ZStack {
                     PositionedCurrentLabel(
                         configuration: configuration,

--- a/ENGAGEHF/Resources/Localizable.xcstrings
+++ b/ENGAGEHF/Resources/Localizable.xcstrings
@@ -4,9 +4,6 @@
     "" : {
 
     },
-    "%@" : {
-
-    },
     "%@ Date: %@" : {
       "localizations" : {
         "en" : {
@@ -113,15 +110,6 @@
     "Add Measurement: %@" : {
 
     },
-    "Add Medications" : {
-
-    },
-    "Add Mock" : {
-
-    },
-    "Add mock notification" : {
-
-    },
     "All Data" : {
 
     },
@@ -189,9 +177,6 @@
         }
       }
     },
-    "Content ..." : {
-
-    },
     "Current" : {
 
     },
@@ -226,9 +211,6 @@
 
     },
     "Expansion Button" : {
-
-    },
-    "Expected Progress: %lf" : {
 
     },
     "Failed to fetch HKUnits for the given samples." : {
@@ -420,12 +402,6 @@
         }
       }
     },
-    "List With Sections" : {
-
-    },
-    "List Without Sections" : {
-
-    },
     "Medication Label: %@" : {
 
     },
@@ -545,9 +521,6 @@
     "Show less" : {
 
     },
-    "Show Measurements" : {
-
-    },
     "Show more" : {
 
     },
@@ -641,9 +614,6 @@
         }
       }
     },
-    "Tap Here" : {
-
-    },
     "Target" : {
 
     },
@@ -659,13 +629,7 @@
     "Trends" : {
 
     },
-    "Trigger Blood Pressure Measurement" : {
-
-    },
     "Trigger Sheet" : {
-
-    },
-    "Trigger Weight Measurement" : {
 
     },
     "Unable to create time interval for date: %@" : {

--- a/ENGAGEHF/Supporting Files/Info.plist
+++ b/ENGAGEHF/Supporting Files/Info.plist
@@ -16,7 +16,6 @@
 	<key>UIBackgroundModes</key>
 	<array>
 		<string>fetch</string>
-		<string>processing</string>
 		<string>remote-notification</string>
 	</array>
 </dict>

--- a/ENGAGEHF/Supporting Files/Info.plist
+++ b/ENGAGEHF/Supporting Files/Info.plist
@@ -15,7 +15,6 @@
 	</dict>
 	<key>UIBackgroundModes</key>
 	<array>
-		<string>fetch</string>
 		<string>remote-notification</string>
 	</array>
 </dict>


### PR DESCRIPTION
# Disable background processing mode

## :recycle: Current situation & Problem
The test flight release for the Push notifications PR is failing to build because:

Asset validation failed (90771) Missing Info.plist value. The Info.plist key 'BGTaskSchedulerPermittedIdentifiers' must contain a list of identifiers used to submit and handle tasks when 'UIBackgroundModes' has a value of 'processing'. For more information, refer to the Information Property List Key Reference at https://developer.apple.com/library/ios/documentation/General/Reference/InfoPlistKeyReference/Introduction/Introduction.html. (ID: 9442fefd-0aba-42d6-ac83-1dca6362db11)


## :gear: Release Notes 
I believe we do not need to have 'processing' mode enabled, so I've disabled it. On the simulator, no behavior changed, and the test notifications I manually dragged and dropped into the simulator were delivered successfully.

I also fixed a bug where the educational videos were only being fetched on change of account, so when we open the app after completely quitting, the educational videos did not appear. Additionally, I fixed a bug where the medication gauge would always be empty when we sign out and sign back in with a different user.


## :books: Documentation
NA


## :white_check_mark: Testing
Manually tested push notifications using the simulator's "drag and drop" functionality.


### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [X] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).
