### PR TITLE
Fix testing bug

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -31,7 +31,7 @@ jobs:
       contents: read
   buildandtest:
     name: Build and Test
-    uses: StanfordBDHG/.github/.github/workflows/xcodebuild-or-fastlane.yml@v2
+    uses: StanfordBDHG/.github/.github/workflows/xcodebuild-or-fastlane.yml@v2.1.5
     permissions:
       contents: read
     with:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -31,7 +31,7 @@ jobs:
       contents: read
   buildandtest:
     name: Build and Test
-    uses: StanfordBDHG/.github/.github/workflows/xcodebuild-or-fastlane.yml@v2.1.5
+    uses: StanfordBDHG/.github/.github/workflows/xcodebuild-or-fastlane.yml@v2
     permissions:
       contents: read
     with:

--- a/ENGAGEHF.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ENGAGEHF.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -186,8 +186,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/StanfordSpezi/Spezi",
       "state" : {
-        "revision" : "77550134ea4cf7cd05314bc44ccb13f7495503fc",
-        "version" : "1.7.2"
+        "revision" : "f1f6fb4d275d5685b612ef84bf847f9740fed47f",
+        "version" : "1.7.3"
       }
     },
     {
@@ -330,8 +330,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-collections.git",
       "state" : {
-        "revision" : "3d2dc41a01f9e49d84f0a3925fb858bed64f702d",
-        "version" : "1.1.2"
+        "revision" : "9bf03ff58ce34478e66aaee630e491823326fd06",
+        "version" : "1.1.3"
       }
     },
     {

--- a/ENGAGEHF.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ENGAGEHF.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -49,7 +49,7 @@
     {
       "identity" : "fhirmodels",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/FHIRModels.git",
+      "location" : "https://github.com/apple/FHIRModels",
       "state" : {
         "revision" : "861afd5816a98d38f86220eab2f812d76cad84a0",
         "version" : "0.5.0"
@@ -114,8 +114,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/StanfordBDHG/HealthKitOnFHIR.git",
       "state" : {
-        "revision" : "b0cfe35a2263a517b22196b559d2dd1d1e2afcd9",
-        "version" : "0.2.9"
+        "revision" : "c24e316311ff9813cb1fe32cd8820bcca6e5e7f2",
+        "version" : "0.2.10"
       }
     },
     {
@@ -357,8 +357,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-protobuf.git",
       "state" : {
-        "revision" : "e17d61f26df0f0e06f58f6977ba05a097a720106",
-        "version" : "1.27.1"
+        "revision" : "564597ad2fe2513a94dd8f3ba27ea2ff4be3cb37",
+        "version" : "1.28.0"
       }
     },
     {

--- a/ENGAGEHF.xcodeproj/xcshareddata/xcschemes/ENGAGEHF.xcscheme
+++ b/ENGAGEHF.xcodeproj/xcshareddata/xcschemes/ENGAGEHF.xcscheme
@@ -115,7 +115,7 @@
          </CommandLineArgument>
          <CommandLineArgument
             argument = "--assumeOnboardingComplete"
-            isEnabled = "YES">
+            isEnabled = "NO">
          </CommandLineArgument>
          <CommandLineArgument
             argument = "--setupTestEnvironment"

--- a/ENGAGEHF/Account/AdditionalAccountSections.swift
+++ b/ENGAGEHF/Account/AdditionalAccountSections.swift
@@ -6,6 +6,8 @@
 // SPDX-License-Identifier: MIT
 //
 
+import SpeziBluetooth
+import SpeziDevicesUI
 import SpeziLicense
 import SwiftUI
 
@@ -26,6 +28,16 @@ struct AdditionalAccountSections: View {
                 NotificationSettingsView()
             } label: {
                 Text("Notifications")
+            }
+            NavigationLink {
+                NavigationStack {
+                    DevicesView(appName: ENGAGEHF.appName ?? "ENGAGE") {
+                        Text("Hold down the Bluetooth button for 3 seconds to put the device into pairing mode.")
+                    }
+                    .bluetoothScanningOptions(advertisementStaleInterval: 15)
+                }
+            } label: {
+                Text("Bluetooth Devices")
             }
         }
         Section {

--- a/ENGAGEHF/Account/InvitationCodeModule.swift
+++ b/ENGAGEHF/Account/InvitationCodeModule.swift
@@ -106,11 +106,7 @@ class InvitationCodeModule: Module, EnvironmentAccessible {
         let password = "123456789"
 
         if let details = account.details {
-            if details.email == email {
-                logger.debug("Test account was already set up")
-                return
-            }
-
+            // always start logged out, even if testing account had already been set up
             try await accountService.logout()
         }
 

--- a/ENGAGEHF/Account/InvitationCodeModule.swift
+++ b/ENGAGEHF/Account/InvitationCodeModule.swift
@@ -105,7 +105,7 @@ class InvitationCodeModule: Module, EnvironmentAccessible {
         let email = "test@engage.stanford.edu"
         let password = "123456789"
 
-        if let details = account.details {
+        if account.details != nil {
             // always start logged out, even if testing account had already been set up
             try await accountService.logout()
         }

--- a/ENGAGEHF/Home.swift
+++ b/ENGAGEHF/Home.swift
@@ -67,16 +67,6 @@ struct HomeView: View {
                 .tabItem {
                     Label("Education", systemImage: "brain")
                 }
-            NavigationStack {
-                DevicesView(appName: ENGAGEHF.appName ?? "ENGAGE") {
-                    Text("Hold down the Bluetooth button for 3 seconds to put the device into pairing mode.")
-                }
-                    .bluetoothScanningOptions(advertisementStaleInterval: 15)
-            }
-                .tag(Tabs.devices)
-                .tabItem {
-                    Label("Devices", systemImage: "sensor.fill")
-                }
         }
             .sheet(isPresented: $navigationManager.showHealthSummary) {
                 HealthSummaryView()

--- a/ENGAGEHF/Medications/MedicationsList.swift
+++ b/ENGAGEHF/Medications/MedicationsList.swift
@@ -60,4 +60,8 @@ struct MedicationsList: View {
             )
         ]
     )
+        .previewWith(standard: ENGAGEHFStandard()) {
+            MedicationsManager()
+            NavigationManager()
+        }
 }

--- a/ENGAGEHF/Medications/RowContent/DosageGauge/CapsuleStack.swift
+++ b/ENGAGEHF/Medications/RowContent/DosageGauge/CapsuleStack.swift
@@ -18,7 +18,7 @@ struct CapsuleStack: View {
         GeometryReader { geometry in
             ZStack(alignment: .leading) {
                 Capsule()
-                    .foregroundStyle(Color(.systemGray6))
+                    .foregroundStyle(.quaternary)
                 Capsule()
                     .frame(width: progress * geometry.size.width)
                     .foregroundStyle(.accent)

--- a/ENGAGEHF/Onboarding/NotificationPermissions.swift
+++ b/ENGAGEHF/Onboarding/NotificationPermissions.swift
@@ -40,20 +40,19 @@ struct NotificationPermissions: View {
                 OnboardingActionsView(
                     "NOTIFICATION_PERMISSIONS_BUTTON",
                     action: {
-                        do {
-                            notificationProcessing = true
-                            // Notification Authorization is not available in the preview simulator.
-                            if ProcessInfo.processInfo.isPreviewSimulator {
-                                try await _Concurrency.Task.sleep(for: .seconds(5))
-                            } else {
-                                _ = try await notificationManager.requestNotificationPermissions()
-                            }
-                        } catch {
-                            print("Could not request notification permissions.")
+                        defer {
+                            notificationProcessing = false
+                            onboardingNavigationPath.nextStep()
                         }
-                        notificationProcessing = false
                         
-                        onboardingNavigationPath.nextStep()
+                        notificationProcessing = true
+                        
+                        // Notification Authorization is not available in the preview simulator.
+                        if ProcessInfo.processInfo.isPreviewSimulator {
+                            try await _Concurrency.Task.sleep(for: .seconds(5))
+                        } else {
+                            _ = try await notificationManager.requestNotificationPermissions()
+                        }
                     }
                 )
             }

--- a/ENGAGEHF/Resources/Localizable.xcstrings
+++ b/ENGAGEHF/Resources/Localizable.xcstrings
@@ -152,6 +152,9 @@
         }
       }
     },
+    "Bluetooth Devices" : {
+
+    },
     "Cancel" : {
 
     },
@@ -202,9 +205,6 @@
 
     },
     "defaultLoadingError" : {
-
-    },
-    "Devices" : {
 
     },
     "Dismiss Button" : {

--- a/ENGAGEHF/Resources/Localizable.xcstrings
+++ b/ENGAGEHF/Resources/Localizable.xcstrings
@@ -4,6 +4,9 @@
     "" : {
 
     },
+    "%@" : {
+
+    },
     "%@ Date: %@" : {
       "localizations" : {
         "en" : {
@@ -110,6 +113,15 @@
     "Add Measurement: %@" : {
 
     },
+    "Add Medications" : {
+
+    },
+    "Add Mock" : {
+
+    },
+    "Add mock notification" : {
+
+    },
     "All Data" : {
 
     },
@@ -177,6 +189,9 @@
         }
       }
     },
+    "Content ..." : {
+
+    },
     "Current" : {
 
     },
@@ -211,6 +226,9 @@
 
     },
     "Expansion Button" : {
+
+    },
+    "Expected Progress: %lf" : {
 
     },
     "Failed to fetch HKUnits for the given samples." : {
@@ -402,6 +420,12 @@
         }
       }
     },
+    "List With Sections" : {
+
+    },
+    "List Without Sections" : {
+
+    },
     "Medication Label: %@" : {
 
     },
@@ -521,6 +545,9 @@
     "Show less" : {
 
     },
+    "Show Measurements" : {
+
+    },
     "Show more" : {
 
     },
@@ -614,6 +641,9 @@
         }
       }
     },
+    "Tap Here" : {
+
+    },
     "Target" : {
 
     },
@@ -629,7 +659,13 @@
     "Trends" : {
 
     },
+    "Trigger Blood Pressure Measurement" : {
+
+    },
     "Trigger Sheet" : {
+
+    },
+    "Trigger Weight Measurement" : {
 
     },
     "Unable to create time interval for date: %@" : {

--- a/ENGAGEHFUITests/AccountTests.swift
+++ b/ENGAGEHFUITests/AccountTests.swift
@@ -17,7 +17,7 @@ final class AccountTests: XCTestCase {
         continueAfterFailure = false
 
         let app = XCUIApplication()
-        app.launchArguments = ["--assumeOnboardingComplete", "--setupTestEnvironment"]
+        app.launchArguments = ["--assumeOnboardingComplete", "--setupTestEnvironment", "--useFirebaseEmulator"]
         app.launch()
     }
 
@@ -57,7 +57,8 @@ final class AccountTests: XCTestCase {
         app.buttons["Login"].tap()
 
         // ensure home view is in focus
-        XCTAssert(app.buttons["Home"].waitForExistence(timeout: 2.0))
-        app.buttons["Home"].tap()
+        let tabBar = app.tabBars["Tab Bar"]
+        XCTAssert(tabBar.buttons["Home"].waitForExistence(timeout: 2))
+        tabBar.buttons["Home"].tap()
     }
 }

--- a/ENGAGEHFUITests/NotificationSettingsUITests.swift
+++ b/ENGAGEHFUITests/NotificationSettingsUITests.swift
@@ -86,9 +86,11 @@ extension XCUIApplication {
         // Return the tested toggle to the initial state
         var count = 0
         let countLimit = 3
-        while try XCTUnwrap(testedToggle.value as? String, "Failed to unwrap toggle value.") != expectedInitialValue {
+        while try XCTUnwrap(testedToggle.value as? String, "Failed to unwrap toggle value.") != expectedInitialValue, count < countLimit {
             testedToggle.descendants(matching: .switch).firstMatch.tap()
             XCTAssertLessThan(count, countLimit, "Failed to reset toggle to initial value \(expectedInitialValue)")
+            
+            count += 1
         }
     }
 }

--- a/ENGAGEHFUITests/OnboardingUITests.swift
+++ b/ENGAGEHFUITests/OnboardingUITests.swift
@@ -165,7 +165,7 @@ extension XCUIApplication {
     }
     
     fileprivate func assertOnboardingComplete() {
-        XCTAssert(staticTexts["Home"].waitForExistence(timeout: 5))
+        XCTAssert(staticTexts["Home"].waitForExistence(timeout: 10))
         
         let tabBar = tabBars["Tab Bar"]
         XCTAssert(tabBar.buttons["Home"].waitForExistence(timeout: 2))


### PR DESCRIPTION
# Fix failing account test

## :recycle: Current situation & Problem
Currently, Account UI tests do not use the firebase emulator, and when the testing account is already signed in the invitation code module's `setupTestEnvironment` does not log out and try to sign back in, instead assuming that the account has been setup correctly. However, this can cause a test failure when the account is already signed in on the client, but the account does not exist on the backend. This is especially relevant with the security rules that exist on the production server, which is what the test used to use since it did not use the firebase emulator.


## :gear: Release Notes 
- `testInAppLogin` now uses the firebase emulator.
- `setupTestEnvironment` now signs out and attempts to sign back in with the test account (signing up / creating a new account if the operation fails) regardless of whether or not the testing account has already been set up previously.
- Also tweaked `testNotificationSettings` to try reseting the toggle back to the initial value at most 3 times.


## :books: Documentation
NA


## :white_check_mark: Testing
No new tests.


### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [X] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).
