### PR TITLE
Bump SpeziFirebase and SpeziAccount

### DIFF
--- a/ENGAGEHF.xcodeproj/project.pbxproj
+++ b/ENGAGEHF.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 55;
+	objectVersion = 60;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -1199,7 +1199,7 @@
 				};
 			};
 			buildConfigurationList = 653A2548283387FE005D4D48 /* Build configuration list for PBXProject "ENGAGEHF" */;
-			compatibilityVersion = "Xcode 13.0";
+			compatibilityVersion = "Xcode 15.0";
 			developmentRegion = en;
 			hasScannedForEncodings = 0;
 			knownRegions = (
@@ -2093,7 +2093,7 @@
 			repositoryURL = "https://github.com/StanfordSpezi/SpeziDevices.git";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 1.2.1;
+				minimumVersion = 1.3.0;
 			};
 		};
 		A9A0BF012C13121D00B8F3F3 /* XCRemoteSwiftPackageReference "SpeziNetworking" */ = {

--- a/ENGAGEHF.xcodeproj/project.pbxproj
+++ b/ENGAGEHF.xcodeproj/project.pbxproj
@@ -1981,7 +1981,7 @@
 			repositoryURL = "https://github.com/StanfordSpezi/SpeziAccount.git";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = "2.0.0-beta.4";
+				minimumVersion = "2.0.0-beta.7";
 			};
 		};
 		2FE5DC6529EDD894004B9AB4 /* XCRemoteSwiftPackageReference "SpeziContact" */ = {
@@ -2005,7 +2005,7 @@
 			repositoryURL = "https://github.com/StanfordSpezi/SpeziFirebase.git";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = "2.0.0-beta.1";
+				minimumVersion = "2.0.0-beta.3";
 			};
 		};
 		2FE5DC8229EDD934004B9AB4 /* XCRemoteSwiftPackageReference "SpeziQuestionnaire" */ = {

--- a/ENGAGEHF.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ENGAGEHF.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -114,8 +114,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/StanfordBDHG/HealthKitOnFHIR.git",
       "state" : {
-        "revision" : "c24e316311ff9813cb1fe32cd8820bcca6e5e7f2",
-        "version" : "0.2.10"
+        "branch" : "fix/swiftlint-dependency",
+        "revision" : "4c4c4d7020016e01904e07763a39088e5a4e132c"
       }
     },
     {
@@ -195,8 +195,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/StanfordSpezi/SpeziAccount.git",
       "state" : {
-        "revision" : "6b1603d2dd95b1787cfb0cbdce32a4b4bebb79ae",
-        "version" : "2.0.0-beta.5"
+        "revision" : "7e78ee9e7e4df2071a18ac0fc722671ac1dcfac4",
+        "version" : "2.0.0-beta.7"
       }
     },
     {
@@ -222,8 +222,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/StanfordSpezi/SpeziDevices.git",
       "state" : {
-        "revision" : "cfba7691b6211bb2f566a8c263ff973921ee555b",
-        "version" : "1.2.2"
+        "revision" : "dc8dcd53773b9bb4041870b0f65cec32f7ed5108",
+        "version" : "1.3.0"
       }
     },
     {
@@ -231,8 +231,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/StanfordSpezi/SpeziFirebase.git",
       "state" : {
-        "revision" : "12e7b779a3339737ea100b4eb7491072d4e83cd5",
-        "version" : "2.0.0-beta.2"
+        "revision" : "d0cb58fc43c99e632446b43c5cb56943f8339bf2",
+        "version" : "2.0.0-beta.3"
       }
     },
     {
@@ -310,7 +310,7 @@
     {
       "identity" : "swift-argument-parser",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-argument-parser",
+      "location" : "https://github.com/apple/swift-argument-parser.git",
       "state" : {
         "revision" : "41982a3656a71c768319979febd796c6fd111d5c",
         "version" : "1.5.0"

--- a/ENGAGEHFUITests/AccountTests.swift
+++ b/ENGAGEHFUITests/AccountTests.swift
@@ -39,11 +39,9 @@ final class AccountTests: XCTestCase {
         XCTAssert(app.alerts[alert].waitForExistence(timeout: 6.0))
         app.alerts[alert].buttons["Logout"].tap()
 
-        sleep(2)
-
 
         // Login
-        if app.buttons["I Already Have an Account"].waitForExistence(timeout: 2.0) {
+        if app.buttons["I Already Have an Account"].waitForExistence(timeout: 6.0) {
             app.buttons["I Already Have an Account"].tap()
         }
 


### PR DESCRIPTION
# Bump SpeziFirebase and SpeziAccount

## :recycle: Current situation & Problem
This PR upgrades SpeziFirebase and SpeziAccount to fix some issues around associating the current user account on app startup.

## :gear: Release Notes 
* Fixed an issue where the current user account wouldn't be properly associated on initial app startup

## :books: Documentation
--

## :white_check_mark: Testing
--

### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).
