### PR TITLE
Handle Education Video fetching failure with content unavailable view with ContentUnavailableView

### DIFF
--- a/ENGAGEHF/Education/Education.swift
+++ b/ENGAGEHF/Education/Education.swift
@@ -8,33 +8,40 @@
 
 import SwiftUI
 
-
 struct Education: View {
     @Binding var presentingAccount: Bool
     
     @Environment(VideoManager.self) private var videoManager
     @Environment(NavigationManager.self) private var navigationManager
     
-    
     var body: some View {
         @Bindable var navigationManager = navigationManager
         
         NavigationStack(path: $navigationManager.educationPath) {
-            VideoList(videoCollections: videoManager.videoCollections)
-                .accessibilityIdentifier("Video List")
-                .navigationTitle("Education")
-                .toolbar {
-                    if AccountButton.shouldDisplay {
-                        AccountButton(isPresented: $presentingAccount)
-                    }
+            Group {
+                if videoManager.videoCollections.isEmpty {
+                    ContentUnavailableView(
+                        "No Educational Videos",
+                        systemImage: "video.slash",
+                        description: Text("There are currently no educational videos available.")
+                    )
+                } else {
+                    VideoList(videoCollections: videoManager.videoCollections.filter { !$0.videos.isEmpty })
                 }
-                .navigationDestination(for: Video.self) { video in
-                    VideoView(video)
+            }
+            .accessibilityIdentifier("Video List")
+            .navigationTitle("Education")
+            .toolbar {
+                if AccountButton.shouldDisplay {
+                    AccountButton(isPresented: $presentingAccount)
                 }
+            }
+            .navigationDestination(for: Video.self) { video in
+                VideoView(video)
+            }
         }
     }
 }
-
 
 #if DEBUG
 #Preview {

--- a/ENGAGEHF/Education/VideoList.swift
+++ b/ENGAGEHF/Education/VideoList.swift
@@ -8,31 +8,36 @@
 
 import SwiftUI
 
-
 struct VideoList: View {
     let videoCollections: [VideoCollection]
     
-    
     var body: some View {
-        ScrollView {
-            LazyVStack(spacing: 12) {
-                ForEach(videoCollections.sorted(by: { $0.orderIndex < $1.orderIndex })) { videoCollection in
-                    StudyApplicationListCard {
-                        VideoListSection(
-                            title: videoCollection.title,
-                            subtitle: videoCollection.description,
-                            videos: videoCollection.videos
-                        )
-                    }
+        if videoCollections.isEmpty {
+            ContentUnavailableView(
+                "No Videos",
+                systemImage: "video.slash",
+                description: Text("There are currently no videos in any collection.")
+            )
+        } else {
+            ScrollView {
+                LazyVStack(spacing: 12) {
+                    ForEach(videoCollections.sorted(by: { $0.orderIndex < $1.orderIndex })) { videoCollection in
+                        StudyApplicationListCard {
+                            VideoListSection(
+                                title: videoCollection.title,
+                                subtitle: videoCollection.description,
+                                videos: videoCollection.videos
+                            )
+                        }
                         .accessibilityIdentifier("Video Section: \(videoCollection.title)")
+                    }
                 }
-            }
                 .padding()
-        }
+            }
             .background(Color(.systemGroupedBackground))
+        }
     }
 }
-
 
 #if DEBUG
 #Preview {
@@ -48,8 +53,8 @@ struct VideoList: View {
             )
         ]
     )
-        .previewWith(standard: ENGAGEHFStandard()) {
-            NavigationManager()
-        }
+    .previewWith(standard: ENGAGEHFStandard()) {
+        NavigationManager()
+    }
 }
 #endif

--- a/ENGAGEHF/Resources/Localizable.xcstrings
+++ b/ENGAGEHF/Resources/Localizable.xcstrings
@@ -425,10 +425,16 @@
     "No Data" : {
 
     },
+    "No Educational Videos" : {
+
+    },
     "No medication recommendations" : {
 
     },
     "No recent %@ measurement available" : {
+
+    },
+    "No Videos" : {
 
     },
     "No vitals" : {
@@ -654,6 +660,12 @@
     },
     "The invitation code is invalid or has already been used." : {
       "comment" : "Invitation Code Invalid"
+    },
+    "There are currently no educational videos available." : {
+
+    },
+    "There are currently no videos in any collection." : {
+
     },
     "Thumbnail Image: %@" : {
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ SPDX-License-Identifier: MIT
 This repository contains the ENGAGE-HF.
 The ENGAGE-HF is using the [Spezi](https://github.com/StanfordSpezi/Spezi) ecosystem and builds on top of the [Stanford Spezi Template Application](https://github.com/StanfordSpezi/SpeziTemplateApplication).
 
-> [!NOTE]  
+> [!NOTE]
 > Do you want to learn more about the Stanford Spezi Template Application and how to use, extend, and modify this application? Check out the [Stanford Spezi Template Application documentation](https://stanfordspezi.github.io/SpeziTemplateApplication)
 
 


### PR DESCRIPTION
# Handle Education Video fetching failure with content unavailable view with ContentUnavailableView
## :recycle: Current situation & Problem
This PR implements the ContentUnavailableView for the education video fetching failure(s) and should fix the issue #84 - also makes the note in the readme formatted correctly (absolutly minor change).

## :gear: Release Notes 
The Education tab now displays a "Content Unavailable" view when no educational videos are present, improving user feedback. Empty video collections are filtered out, ensuring users only see sections with actual content 🎥.

## :white_check_mark: Testing
Tests passing

### :children_crossing: Info
This is my first PR in this project, I'm happy for any improvments and feedback for my code {style} 🙆‍♂️ 

### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).
