### PR TITLE
Automatically Generate Release Notes Based on GitHub Releases

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -107,16 +107,16 @@ jobs:
             echo "version: ${{ inputs.version }}"
           fi
           echo "releasenotes: ${{ inputs.releasenotes }}"
-  buildandtest:
-    name: Build and Test
-    needs: determineenvironment
-    uses: ./.github/workflows/build-and-test.yml
-    permissions:
-      contents: read
-    secrets: inherit
+  # buildandtest:
+  #   name: Build and Test
+  #   needs: determineenvironment
+  #   uses: ./.github/workflows/build-and-test.yml
+  #   permissions:
+  #     contents: read
+  #   secrets: inherit
   iosapptestflightdeployment:
     name: iOS App TestFlight Deployment
-    needs: [determineenvironment, vars, buildandtest]
+    needs: [determineenvironment, vars] # buildandtest
     uses: StanfordBDHG/.github/.github/workflows/xcodebuild-or-fastlane.yml@v2
     permissions:
       contents: read

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -125,5 +125,5 @@ jobs:
       environment: ${{ needs.determineenvironment.outputs.environment }}
       googleserviceinfoplistpath: 'ENGAGEHF/Supporting Files/GoogleService-Info.plist'
       setupsigning: true
-      fastlanelane: deploy environment:"${{ needs.determineenvironment.outputs.environment }}" appidentifier:"${{ needs.vars.outputs.appidentifier }}" provisioningProfile:"${{ needs.vars.outputs.provisioningProfileName }}" versionname:"${{ needs.vars.outputs.version }} releasenotes:"${{ inputs.releasenotes }}"
+      fastlanelane: deploy environment:"${{ needs.determineenvironment.outputs.environment }}" appidentifier:"${{ needs.vars.outputs.appidentifier }}" provisioningProfile:"${{ needs.vars.outputs.provisioningProfileName }}" versionname:"${{ needs.vars.outputs.version }}" releasenotes:"${{ inputs.releasenotes }}"
     secrets: inherit

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -107,16 +107,16 @@ jobs:
             echo "version: ${{ inputs.version }}"
           fi
           echo "releasenotes: ${{ inputs.releasenotes }}"
-  # buildandtest:
-  #   name: Build and Test
-  #   needs: determineenvironment
-  #   uses: ./.github/workflows/build-and-test.yml
-  #   permissions:
-  #     contents: read
-  #   secrets: inherit
+  buildandtest:
+    name: Build and Test
+    needs: determineenvironment
+    uses: ./.github/workflows/build-and-test.yml
+    permissions:
+      contents: read
+    secrets: inherit
   iosapptestflightdeployment:
     name: iOS App TestFlight Deployment
-    needs: [determineenvironment, vars] # buildandtest
+    needs: [determineenvironment, vars, buildandtest]
     uses: StanfordBDHG/.github/.github/workflows/xcodebuild-or-fastlane.yml@v2
     permissions:
       contents: read

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -29,6 +29,12 @@ on:
           The semantic version of the app that should be released.
         required: true
         type: string
+      releasenotes:
+        description: |
+          Release notes of what changed in this version.
+        required: false
+        type: string
+        default: Bug fixes and performance improvements.
   workflow_call:
     inputs:
       environment:
@@ -42,6 +48,12 @@ on:
           The semantic version of the app that should be released.
         required: true
         type: string
+      releasenotes:
+        description: |
+          Release notes of what changed in this version.
+        required: false
+        type: string
+        default: Bug fixes and performance improvements.
 
 concurrency:
   group: deployment
@@ -61,8 +73,10 @@ jobs:
         run: |
           if [[ -z "${{ inputs.environment }}" ]]; then
             echo "environment=staging" >> $GITHUB_OUTPUT
+            echo "environment: staging"
           else
             echo "environment=${{ inputs.environment }}" >> $GITHUB_OUTPUT
+            echo "environment: ${{ inputs.environment }}"
           fi
   vars:
     name: Inject Environment Variables In Deployment Workflow
@@ -92,6 +106,7 @@ jobs:
             echo "version=${{ inputs.version }}" >> $GITHUB_OUTPUT
             echo "version: ${{ inputs.version }}"
           fi
+          echo "releasenotes: ${{ inputs.releasenotes }}"
   buildandtest:
     name: Build and Test
     needs: determineenvironment
@@ -110,5 +125,5 @@ jobs:
       environment: ${{ needs.determineenvironment.outputs.environment }}
       googleserviceinfoplistpath: 'ENGAGEHF/Supporting Files/GoogleService-Info.plist'
       setupsigning: true
-      fastlanelane: deploy environment:"${{ needs.determineenvironment.outputs.environment }}" appidentifier:"${{ needs.vars.outputs.appidentifier }}" provisioningProfile:"${{ needs.vars.outputs.provisioningProfileName }}" versionname:"${{ needs.vars.outputs.version }}"
+      fastlanelane: deploy environment:"${{ needs.determineenvironment.outputs.environment }}" appidentifier:"${{ needs.vars.outputs.appidentifier }}" provisioningProfile:"${{ needs.vars.outputs.provisioningProfileName }}" versionname:"${{ needs.vars.outputs.version }} releasenotes:"${{ inputs.releasenotes }}"
     secrets: inherit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,8 +77,9 @@ jobs:
         releasenotes = re.sub(r'\n\s*\n', '\n', releasenotes).strip()
 
         # Escape single quotes and line breaks
-        releasenotes = releasenotes.replace("'", "\\'")
-        releasenotes = releasenotes.replace("\n", "\\n")
+        releasenotes = releasenotes.replace('"', "'")
+        releasenotes = releasenotes.replace("'", "\\\'")
+        releasenotes = releasenotes.replace("\n", "\\\n")
 
         # Write cleaned releasenotes to GITHUB_OUTPUT
         with open(os.environ['GITHUB_OUTPUT'], 'a') as output_file:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,24 +49,24 @@ jobs:
         releasenotes = release.get('body', '')
 
         # Extract the "What's Changed" section
-        match = re.search(r"(## What's Changed.*?)(\n##|$)", changelog, flags=re.DOTALL)
+        match = re.search(r"(## What's Changed.*?)(\n##|$)", releasenotes, flags=re.DOTALL)
         if match:
-            changelog = match.group(1)
+            releasenotes = match.group(1)
         else:
-            changelog = "Bug fixes and performance improvements."
+            releasenotes = "Bug fixes and performance improvements."
 
         # Remove all Markdown formatting (optional, customize as needed)
-        changelog = re.sub(r'^#+\s*', '', changelog, flags=re.MULTILINE)  # Remove all headers
-        changelog = re.sub(r'\*\*|__|\*|_', '', changelog)  # Remove bold, italics, etc.
-        changelog = re.sub(r'\[(.*?)\]\((.*?)\)', r'\1', changelog)  # Remove links but keep text
-        changelog = re.sub(r'https://github\.com/[^/]+/[^/]+/pull/(\d+)', r'#\1', changelog)  # Shorten pull request URLs
+        releasenotes = re.sub(r'^#+\s*', '', releasenotes, flags=re.MULTILINE)  # Remove all headers
+        releasenotes = re.sub(r'\*\*|__|\*|_', '', releasenotes)  # Remove bold, italics, etc.
+        releasenotes = re.sub(r'\[(.*?)\]\((.*?)\)', r'\1', releasenotes)  # Remove links but keep text
+        releasenotes = re.sub(r'https://github\.com/[^/]+/[^/]+/pull/(\d+)', r'#\1', releasenotes)  # Shorten pull request URLs
 
         # Remove excess blank lines
-        changelog = re.sub(r'\n\s*\n', '\n', changelog).strip()
+        releasenotes = re.sub(r'\n\s*\n', '\n', releasenotes).strip()
 
-        # Write cleaned changelog to GITHUB_OUTPUT
+        # Write cleaned releasenotes to GITHUB_OUTPUT
         with open(os.environ['GITHUB_OUTPUT'], 'a') as output_file:
-            output_file.write(f"changelog<<EOF\n{changelog}\nEOF\n")
+            output_file.write(f"releasenotes<<EOF\n{releasenotes}\nEOF\n")
         EOF
     - name: Formatted Release Notes
       run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,17 +84,17 @@ jobs:
       run: |
         echo "Formatted Release Notes:"
         echo "${{ steps.releasenotes.outputs.releasenotes }}"
-  # build-and-test:
-  #   name: Build and Test
-  #   uses: ./.github/workflows/deployment.yml
-  #   needs: formatreleasenotes
-  #   permissions:
-  #     contents: read
-  #     checks: write
-  #     actions: read
-  #     security-events: write
-  #   secrets: inherit
-  #   with:
-  #     environment: production
-  #     version: ${{ github.event.release.tag_name }}
-  #     releasenotes: ${{ needs.formatreleasenotes.outputs.releasenotes }}
+  build-and-test:
+    name: Build and Test
+    uses: ./.github/workflows/deployment.yml
+    needs: formatreleasenotes
+    permissions:
+      contents: read
+      checks: write
+      actions: read
+      security-events: write
+    secrets: inherit
+    with:
+      environment: production
+      version: ${{ github.event.release.tag_name }}
+      releasenotes: ${{ needs.formatreleasenotes.outputs.releasenotes }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,12 +11,59 @@ name: Release
 on:
   release:
     types: [published]
+  push:
+    branches:
+      - fixReleaseNotes
 
 concurrency:
   group: production
   cancel-in-progress: false
 
 jobs:
+  formatreleasenotes:
+    name: Format Release Notes
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-python@v5
+      with:
+        python-version: '3.x'
+    - name: Install Dependencies
+      run: pip install requests
+    - name: Fetch and Process Changelog
+      id: changelog
+      run: |
+        python <<EOF
+        import re
+        import os
+        import requests
+
+        # Fetch release notes from the GitHub API
+        RELEASE_TAG = "2.0.1"
+        REPO = "StanfordBDHG/ENGAGE-HF-iOS"
+        URL = f"https://api.github.com/repos/{REPO}/releases/tags/{RELEASE_TAG}"
+        response = requests.get(URL)
+        release = response.json()
+        changelog = release.get('body', '')
+
+        # Remove all Markdown formatting
+        changelog = re.sub(r'^#+\s*', '', changelog, flags=re.MULTILINE)  # Remove all headers
+        changelog = re.sub(r'\*\*|__|\*|_', '', changelog)  # Remove bold, italics, etc.
+        changelog = re.sub(r'\[(.*?)\]\((.*?)\)', r'\1', changelog)  # Remove links but keep text
+        changelog = re.sub(r'^Full Changelog:.*$', '', changelog, flags=re.MULTILINE)  # Remove specific line
+        changelog = re.sub(r'https://github\.com/[^/]+/[^/]+/pull/(\d+)', r'#\1', changelog)  # Shorten pull request URLs
+
+        # Remove excess blank lines
+        changelog = re.sub(r'\n\s*\n', '\n', changelog).strip()
+
+        # Write cleaned changelog to GITHUB_OUTPUT
+        with open(os.environ['GITHUB_OUTPUT'], 'a') as output_file:
+            output_file.write(f"changelog<<EOF\n{changelog}\nEOF\n")
+        EOF
+    - name: Use Processed Changelog in Fastlane
+      run: |
+        echo "Processed Changelog:"
+        echo "${{ steps.changelog.outputs.changelog }}"
   build-and-test:
     name: Build and Test
     uses: ./.github/workflows/deployment.yml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,25 +48,25 @@ jobs:
         release = response.json()
         releasenotes = release.get('body', '')
 
-        # Extract only the "What's Changed" section
-        match = re.search(r"## What's Changed(.*?)(##|$)", releasenotes, flags=re.DOTALL)
+        # Extract the "What's Changed" section
+        match = re.search(r"(## What's Changed.*?)(\n##|$)", changelog, flags=re.DOTALL)
         if match:
-            releasenotes = match.group(1).strip()
+            changelog = match.group(1)
         else:
-            releasenotes = "Bug fixes and performance improvements."
+            changelog = "Bug fixes and performance improvements."
 
-        # Remove all Markdown formatting
-        releasenotes = re.sub(r'^#+\s*', '', releasenotes, flags=re.MULTILINE)  # Remove headers
-        releasenotes = re.sub(r'\*\*|__|\*|_', '', releasenotes)  # Remove bold, italics, etc.
-        releasenotes = re.sub(r'\[(.*?)\]\((.*?)\)', r'\1', releasenotes)  # Remove links but keep text
-        releasenotes = re.sub(r'https://github\.com/[^/]+/[^/]+/pull/(\d+)', r'#\1', releasenotes)  # Shorten pull request URLs
+        # Remove all Markdown formatting (optional, customize as needed)
+        changelog = re.sub(r'^#+\s*', '', changelog, flags=re.MULTILINE)  # Remove all headers
+        changelog = re.sub(r'\*\*|__|\*|_', '', changelog)  # Remove bold, italics, etc.
+        changelog = re.sub(r'\[(.*?)\]\((.*?)\)', r'\1', changelog)  # Remove links but keep text
+        changelog = re.sub(r'https://github\.com/[^/]+/[^/]+/pull/(\d+)', r'#\1', changelog)  # Shorten pull request URLs
 
         # Remove excess blank lines
-        releasenotes = re.sub(r'\n\s*\n', '\n', releasenotes).strip()
+        changelog = re.sub(r'\n\s*\n', '\n', changelog).strip()
 
-        # Write cleaned releasenotes to GITHUB_OUTPUT
+        # Write cleaned changelog to GITHUB_OUTPUT
         with open(os.environ['GITHUB_OUTPUT'], 'a') as output_file:
-            output_file.write(f"releasenotes<<EOF\n{releasenotes}\nEOF\n")
+            output_file.write(f"changelog<<EOF\n{changelog}\nEOF\n")
         EOF
     - name: Formatted Release Notes
       run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,26 +53,23 @@ jobs:
         changelog = re.sub(r'^Full Changelog:.*$', '', changelog, flags=re.MULTILINE)  # Remove specific line
         changelog = re.sub(r'https://github\.com/[^/]+/[^/]+/pull/(\d+)', r'#\1', changelog)  # Shorten pull request URLs
 
-        # Remove excess blank lines
-        changelog = re.sub(r'\n\s*\n', '\n', changelog).strip()
-
         # Write cleaned changelog to GITHUB_OUTPUT
         with open(os.environ['GITHUB_OUTPUT'], 'a') as output_file:
             output_file.write(f"changelog<<EOF\n{changelog}\nEOF\n")
         EOF
-    - name: Use Processed Changelog in Fastlane
+    - name: Formatted Release Notes
       run: |
-        echo "Processed Changelog:"
+        echo "Formatted Release Notes:"
         echo "${{ steps.changelog.outputs.changelog }}"
-  build-and-test:
-    name: Build and Test
-    uses: ./.github/workflows/deployment.yml
-    permissions:
-      contents: read
-      checks: write
-      actions: read
-      security-events: write
-    secrets: inherit
-    with:
-      environment: production
-      version: ${{ github.event.release.tag_name }}
+  # build-and-test:
+  #   name: Build and Test
+  #   uses: ./.github/workflows/deployment.yml
+  #   permissions:
+  #     contents: read
+  #     checks: write
+  #     actions: read
+  #     security-events: write
+  #   secrets: inherit
+  #   with:
+  #     environment: production
+  #     version: ${{ github.event.release.tag_name }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,12 +46,21 @@ jobs:
         release = response.json()
         changelog = release.get('body', '')
 
+        # Extract only the "What's Changed" section
+        match = re.search(r"## What's Changed(.*?)(##|$)", changelog, flags=re.DOTALL)
+        if match:
+            changelog = match.group(1).strip()
+        else:
+            changelog = "Bug fixes and performance improvements."
+
         # Remove all Markdown formatting
-        changelog = re.sub(r'^#+\s*', '', changelog, flags=re.MULTILINE)  # Remove all headers
+        changelog = re.sub(r'^#+\s*', '', changelog, flags=re.MULTILINE)  # Remove headers
         changelog = re.sub(r'\*\*|__|\*|_', '', changelog)  # Remove bold, italics, etc.
         changelog = re.sub(r'\[(.*?)\]\((.*?)\)', r'\1', changelog)  # Remove links but keep text
-        changelog = re.sub(r'^Full Changelog:.*$', '', changelog, flags=re.MULTILINE)  # Remove specific line
         changelog = re.sub(r'https://github\.com/[^/]+/[^/]+/pull/(\d+)', r'#\1', changelog)  # Shorten pull request URLs
+
+        # Remove excess blank lines
+        changelog = re.sub(r'\n\s*\n', '\n', changelog).strip()
 
         # Write cleaned changelog to GITHUB_OUTPUT
         with open(os.environ['GITHUB_OUTPUT'], 'a') as output_file:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,7 +77,8 @@ jobs:
         releasenotes = re.sub(r'\n\s*\n', '\n', releasenotes).strip()
 
         # Replace quotation marks with single quotes and line breaks
-        releasenotes = releasenotes.replace('"', "'")
+        releasenotes = releasenotes.replace('"', "’")
+        releasenotes = releasenotes.replace("'", "’")
         releasenotes = releasenotes.replace("\n", "\\\n")
 
         # Write cleaned releasenotes to GITHUB_OUTPUT

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,9 @@ name: Release
 on:
   release:
     types: [published]
+  push:
+    branches:
+      - fixReleaseNotes
 
 concurrency:
   group: production
@@ -38,8 +41,8 @@ jobs:
         import requests
 
         # Fetch release notes from the GitHub API
-        RELEASE_TAG = "${{ github.event.release.tag_name }}"
-        REPO = "${{ github.repository }}"
+        RELEASE_TAG = "2.0.1"
+        REPO = "StanfordBDHG/ENGAGE-HF-iOS"
         URL = f"https://api.github.com/repos/{REPO}/releases/tags/{RELEASE_TAG}"
         response = requests.get(URL)
         release = response.json()
@@ -76,7 +79,7 @@ jobs:
         # Replace quotation marks with single quotes and line breaks
         releasenotes = releasenotes.replace('"', "’")
         releasenotes = releasenotes.replace("'", "’")
-        releasenotes = releasenotes.replace("\n", "\\\n")
+        releasenotes = releasenotes.replace("\n", "\\n")
 
         # Write cleaned releasenotes to GITHUB_OUTPUT
         with open(os.environ['GITHUB_OUTPUT'], 'a') as output_file:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,8 @@ jobs:
   formatreleasenotes:
     name: Format Release Notes
     runs-on: ubuntu-latest
+    outputs:
+      releasenotes: ${{ steps.releasenotes.outputs.releasenotes }}
     steps:
     - uses: actions/checkout@v4
     - uses: actions/setup-python@v5
@@ -30,8 +32,8 @@ jobs:
         python-version: '3.x'
     - name: Install Dependencies
       run: pip install requests
-    - name: Fetch and Process Changelog
-      id: changelog
+    - name: Fetch and Process releasenotes
+      id: releasenotes
       run: |
         python <<EOF
         import re
@@ -44,35 +46,36 @@ jobs:
         URL = f"https://api.github.com/repos/{REPO}/releases/tags/{RELEASE_TAG}"
         response = requests.get(URL)
         release = response.json()
-        changelog = release.get('body', '')
+        releasenotes = release.get('body', '')
 
         # Extract only the "What's Changed" section
-        match = re.search(r"## What's Changed(.*?)(##|$)", changelog, flags=re.DOTALL)
+        match = re.search(r"## What's Changed(.*?)(##|$)", releasenotes, flags=re.DOTALL)
         if match:
-            changelog = match.group(1).strip()
+            releasenotes = match.group(1).strip()
         else:
-            changelog = "Bug fixes and performance improvements."
+            releasenotes = "Bug fixes and performance improvements."
 
         # Remove all Markdown formatting
-        changelog = re.sub(r'^#+\s*', '', changelog, flags=re.MULTILINE)  # Remove headers
-        changelog = re.sub(r'\*\*|__|\*|_', '', changelog)  # Remove bold, italics, etc.
-        changelog = re.sub(r'\[(.*?)\]\((.*?)\)', r'\1', changelog)  # Remove links but keep text
-        changelog = re.sub(r'https://github\.com/[^/]+/[^/]+/pull/(\d+)', r'#\1', changelog)  # Shorten pull request URLs
+        releasenotes = re.sub(r'^#+\s*', '', releasenotes, flags=re.MULTILINE)  # Remove headers
+        releasenotes = re.sub(r'\*\*|__|\*|_', '', releasenotes)  # Remove bold, italics, etc.
+        releasenotes = re.sub(r'\[(.*?)\]\((.*?)\)', r'\1', releasenotes)  # Remove links but keep text
+        releasenotes = re.sub(r'https://github\.com/[^/]+/[^/]+/pull/(\d+)', r'#\1', releasenotes)  # Shorten pull request URLs
 
         # Remove excess blank lines
-        changelog = re.sub(r'\n\s*\n', '\n', changelog).strip()
+        releasenotes = re.sub(r'\n\s*\n', '\n', releasenotes).strip()
 
-        # Write cleaned changelog to GITHUB_OUTPUT
+        # Write cleaned releasenotes to GITHUB_OUTPUT
         with open(os.environ['GITHUB_OUTPUT'], 'a') as output_file:
-            output_file.write(f"changelog<<EOF\n{changelog}\nEOF\n")
+            output_file.write(f"releasenotes<<EOF\n{releasenotes}\nEOF\n")
         EOF
     - name: Formatted Release Notes
       run: |
         echo "Formatted Release Notes:"
-        echo "${{ steps.changelog.outputs.changelog }}"
+        echo "${{ steps.releasenotes.outputs.releasenotes }}"
   # build-and-test:
   #   name: Build and Test
   #   uses: ./.github/workflows/deployment.yml
+  #   needs: formatreleasenotes
   #   permissions:
   #     contents: read
   #     checks: write
@@ -82,3 +85,4 @@ jobs:
   #   with:
   #     environment: production
   #     version: ${{ github.event.release.tag_name }}
+  #     releasenotes: ${{ needs.formatreleasenotes.outputs.releasenotes }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,7 +78,7 @@ jobs:
 
         # Write cleaned releasenotes to GITHUB_OUTPUT
         with open(os.environ['GITHUB_OUTPUT'], 'a') as output_file:
-            output_file.write(f"releasenotes<<EOF\n{releasenotes}\nEOF\n")
+            output_file.write(f"releasenotes<<{releasenotes}\n")
         EOF
     - name: Formatted Release Notes
       run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,13 +53,22 @@ jobs:
         if match:
             releasenotes = match.group(1)
         else:
-            releasenotes = "What's Changed section not found."
+            releasenotes = "Bug fixes and performance improvements."
 
-        # Remove all Markdown formatting
-        releasenotes = re.sub(r'^#+\s*', '', releasenotes, flags=re.MULTILINE)  # Remove all headers
-        releasenotes = re.sub(r'\*\*|__|\*|_', '', releasenotes)  # Remove bold, italics, etc.
-        releasenotes = re.sub(r'\[(.*?)\]\((.*?)\)', r'\1', releasenotes)  # Remove links but keep text
-        releasenotes = re.sub(r'https://github\.com/[^/]+/[^/]+/pull/(\d+)', r'#\1', releasenotes)  # Shorten pull request URLs
+        # Remove bold (**text**), italics (*text* or _text_), and underline (__text__)
+        releasenotes = re.sub(r'\*\*(.*?)\*\*', r'\1', releasenotes)  # Remove **bold**
+        releasenotes = re.sub(r'\*(.*?)\*', r'\1', releasenotes)      # Remove *italics*
+        releasenotes = re.sub(r'_(.*?)_', r'\1', releasenotes)        # Remove _italics/underline_
+        releasenotes = re.sub(r'__(.*?)__', r'\1', releasenotes)      # Remove __underline__
+
+        # Remove all headers (e.g., ## What's Changed)
+        releasenotes = re.sub(r'^#+\s*', '', releasenotes, flags=re.MULTILINE)
+
+        # Remove inline links but keep text (e.g., [text](url) → text)
+        releasenotes = re.sub(r'\[(.*?)\]\((.*?)\)', r'\1', releasenotes)
+
+        # Shorten pull request URLs to reference IDs (e.g., #123)
+        releasenotes = re.sub(r'https://github\.com/[^/]+/[^/]+/pull/(\d+)', r'#\1', releasenotes)
 
         # Replace list items "*" with "-"
         releasenotes = re.sub(r'^\s*\*\s+', '- ', releasenotes, flags=re.MULTILINE)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,9 +76,8 @@ jobs:
         # Remove excess blank lines
         releasenotes = re.sub(r'\n\s*\n', '\n', releasenotes).strip()
 
-        # Escape single quotes and line breaks
+        # Replace quotation marks with single quotes and line breaks
         releasenotes = releasenotes.replace('"', "'")
-        releasenotes = releasenotes.replace("'", "\\\'")
         releasenotes = releasenotes.replace("\n", "\\\n")
 
         # Write cleaned releasenotes to GITHUB_OUTPUT

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,9 +76,13 @@ jobs:
         # Remove excess blank lines
         releasenotes = re.sub(r'\n\s*\n', '\n', releasenotes).strip()
 
+        # Escape single quotes and line breaks
+        releasenotes = releasenotes.replace("'", "\\'")
+        releasenotes = releasenotes.replace("\n", "\\n")
+
         # Write cleaned releasenotes to GITHUB_OUTPUT
         with open(os.environ['GITHUB_OUTPUT'], 'a') as output_file:
-            output_file.write(f"releasenotes<<{releasenotes}\n")
+            output_file.write(f"releasenotes<<EOF\n{releasenotes}\nEOF\n")
         EOF
     - name: Formatted Release Notes
       run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,13 +53,16 @@ jobs:
         if match:
             releasenotes = match.group(1)
         else:
-            releasenotes = "Bug fixes and performance improvements."
+            releasenotes = "What's Changed section not found."
 
-        # Remove all Markdown formatting (optional, customize as needed)
+        # Remove all Markdown formatting
         releasenotes = re.sub(r'^#+\s*', '', releasenotes, flags=re.MULTILINE)  # Remove all headers
         releasenotes = re.sub(r'\*\*|__|\*|_', '', releasenotes)  # Remove bold, italics, etc.
         releasenotes = re.sub(r'\[(.*?)\]\((.*?)\)', r'\1', releasenotes)  # Remove links but keep text
         releasenotes = re.sub(r'https://github\.com/[^/]+/[^/]+/pull/(\d+)', r'#\1', releasenotes)  # Shorten pull request URLs
+
+        # Replace list items "*" with "-"
+        releasenotes = re.sub(r'^\s*\*\s+', '- ', releasenotes, flags=re.MULTILINE)
 
         # Remove excess blank lines
         releasenotes = re.sub(r'\n\s*\n', '\n', releasenotes).strip()

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,9 +11,6 @@ name: Release
 on:
   release:
     types: [published]
-  push:
-    branches:
-      - fixReleaseNotes
 
 concurrency:
   group: production
@@ -41,8 +38,8 @@ jobs:
         import requests
 
         # Fetch release notes from the GitHub API
-        RELEASE_TAG = "2.0.1"
-        REPO = "StanfordBDHG/ENGAGE-HF-iOS"
+        RELEASE_TAG = "${{ github.event.release.tag_name }}"
+        REPO = "${{ github.repository }}"
         URL = f"https://api.github.com/repos/{REPO}/releases/tags/{RELEASE_TAG}"
         response = requests.get(URL)
         release = response.json()

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -13,7 +13,7 @@ APP_CONFIG = {
   default_app_identifier: "edu.stanford.bdh.engagehf",
   default_provisioningProfile: "Stanford BDHG ENGAGE-HF",
   default_version_name: "2.0.1",
-  default_release_notes: "Bug fixes and performance improvements"
+  default_release_notes: "Bug fixes and performance improvements."
 }.freeze
 
 platform :ios do

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -12,7 +12,8 @@ APP_CONFIG = {
   default_environment: "staging",
   default_app_identifier: "edu.stanford.bdh.engagehf",
   default_provisioningProfile: "Stanford BDHG ENGAGE-HF",
-  default_version_name: "2.0.1"
+  default_version_name: "2.0.1",
+  default_release_notes: "Bug fixes and performance improvements"
 }.freeze
 
 platform :ios do
@@ -130,11 +131,13 @@ platform :ios do
     appidentifier = options[:appidentifier].to_s.strip.empty? ? APP_CONFIG[:default_app_identifier] : options[:appidentifier]
     provisioningProfile = options[:provisioningProfile].to_s.strip.empty? ? APP_CONFIG[:default_provisioningProfile] : options[:provisioningProfile]
     versionname = options[:versionname].to_s.strip.empty? ? APP_CONFIG[:default_version_name] : options[:versionname]
+    releasenotes = options[:releasenotes].to_s.strip.empty? ? APP_CONFIG[:default_release_notes] : options[:releasenotes]
 
     UI.message("Using environment: #{environment}")
     UI.message("Using app identifier: #{appidentifier}")
     UI.message("Using provisioning profile: #{provisioningProfile}")
     UI.message("Using version name: #{versionname}")
+    UI.message("Using release notes: #{releasenotes}")
 
     if environment == "production"
       increment_version_number(
@@ -158,6 +161,9 @@ platform :ios do
     if environment == "production"
       deliver(
         app_identifier: appidentifier,
+        release_notes: ({
+          'default' => releasenotes
+        }),
         submit_for_review: true,
         force: true,
         reject_if_possible: true,


### PR DESCRIPTION
# Automatically Generate Release Notes Based on GitHub Releases

## :recycle: Current situation & Problem
- Currently one has to manually set a release not in App Store Connect to finalize an application update.

## :gear: Release Notes 
- Parses the release notes based on the GitHub release tag that is formatted to fit the Apple release notes format.

### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).
