### PR TITLE
Study Finished Screen

### DIFF
--- a/ENGAGEHF.xcodeproj/project.pbxproj
+++ b/ENGAGEHF.xcodeproj/project.pbxproj
@@ -202,6 +202,7 @@
 		56E7083B2BB06F6F00B08F0A /* SwiftPackageList in Frameworks */ = {isa = PBXBuildFile; productRef = 56E7083A2BB06F6F00B08F0A /* SwiftPackageList */; };
 		6504AFF62D40383F001F4A03 /* StudyConcluded.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6504AFF52D40382F001F4A03 /* StudyConcluded.swift */; };
 		6504AFF82D403914001F4A03 /* Icon.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6504AFF72D403914001F4A03 /* Icon.swift */; };
+		6504B0032D40C8BF001F4A03 /* AccountDisabled.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6504B0022D40C8BF001F4A03 /* AccountDisabled.swift */; };
 		653A2551283387FE005D4D48 /* ENGAGEHF.swift in Sources */ = {isa = PBXBuildFile; fileRef = 653A2550283387FE005D4D48 /* ENGAGEHF.swift */; };
 		653A255528338800005D4D48 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 653A255428338800005D4D48 /* Assets.xcassets */; };
 		653A256228338800005D4D48 /* VitalsGraphAggregationUnitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 653A256128338800005D4D48 /* VitalsGraphAggregationUnitTests.swift */; };
@@ -420,6 +421,7 @@
 		4DF506392C2F5104003E7EFB /* DisplayMeasurement.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DisplayMeasurement.swift; sourceTree = "<group>"; };
 		6504AFF52D40382F001F4A03 /* StudyConcluded.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StudyConcluded.swift; sourceTree = "<group>"; };
 		6504AFF72D403914001F4A03 /* Icon.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Icon.swift; sourceTree = "<group>"; };
+		6504B0022D40C8BF001F4A03 /* AccountDisabled.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountDisabled.swift; sourceTree = "<group>"; };
 		653A254D283387FE005D4D48 /* ENGAGEHF.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ENGAGEHF.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		653A2550283387FE005D4D48 /* ENGAGEHF.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ENGAGEHF.swift; sourceTree = "<group>"; };
 		653A255428338800005D4D48 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -1168,6 +1170,7 @@
 				4D8CE0FE2C7540C000560327 /* AdditionalAccountSections.swift */,
 				A96C56BA2C0DFFCE00D6A50B /* InvitationCodeModule.swift */,
 				4DB624852C73F1BF00573807 /* NotificationSettingsView.swift */,
+				6504B0022D40C8BF001F4A03 /* AccountDisabled.swift */,
 			);
 			path = Account;
 			sourceTree = "<group>";
@@ -1405,6 +1408,7 @@
 				4DA20B642C2A0FF100715AA2 /* VitalsCard.swift in Sources */,
 				4DBDD3442BBFAD64001FB0CA /* InvitationCodeError.swift in Sources */,
 				4D8402B52C51D6D200817495 /* MedicationRecommendationSymbol.swift in Sources */,
+				6504B0032D40C8BF001F4A03 /* AccountDisabled.swift in Sources */,
 				9B1864982C9350D30042AC81 /* Account+Binding.swift in Sources */,
 				4D40A4AF2C5A9B4F003DC813 /* VideoPlayer.swift in Sources */,
 				4D84027E2C4EF82D00817495 /* AddMeasurementAsyncButton.swift in Sources */,

--- a/ENGAGEHF.xcodeproj/project.pbxproj
+++ b/ENGAGEHF.xcodeproj/project.pbxproj
@@ -200,6 +200,8 @@
 		4DF5063A2C2F5104003E7EFB /* DisplayMeasurement.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DF506392C2F5104003E7EFB /* DisplayMeasurement.swift */; };
 		56E708352BB06B7100B08F0A /* SpeziLicense in Frameworks */ = {isa = PBXBuildFile; productRef = 56E708342BB06B7100B08F0A /* SpeziLicense */; };
 		56E7083B2BB06F6F00B08F0A /* SwiftPackageList in Frameworks */ = {isa = PBXBuildFile; productRef = 56E7083A2BB06F6F00B08F0A /* SwiftPackageList */; };
+		6504AFF62D40383F001F4A03 /* StudyConcluded.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6504AFF52D40382F001F4A03 /* StudyConcluded.swift */; };
+		6504AFF82D403914001F4A03 /* Icon.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6504AFF72D403914001F4A03 /* Icon.swift */; };
 		653A2551283387FE005D4D48 /* ENGAGEHF.swift in Sources */ = {isa = PBXBuildFile; fileRef = 653A2550283387FE005D4D48 /* ENGAGEHF.swift */; };
 		653A255528338800005D4D48 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 653A255428338800005D4D48 /* Assets.xcassets */; };
 		653A256228338800005D4D48 /* VitalsGraphAggregationUnitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 653A256128338800005D4D48 /* VitalsGraphAggregationUnitTests.swift */; };
@@ -416,6 +418,8 @@
 		4DF5062E2C2F2B00003E7EFB /* SymptomsPicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SymptomsPicker.swift; sourceTree = "<group>"; };
 		4DF506302C2F3421003E7EFB /* VitalsGraph.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VitalsGraph.swift; sourceTree = "<group>"; };
 		4DF506392C2F5104003E7EFB /* DisplayMeasurement.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DisplayMeasurement.swift; sourceTree = "<group>"; };
+		6504AFF52D40382F001F4A03 /* StudyConcluded.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StudyConcluded.swift; sourceTree = "<group>"; };
+		6504AFF72D403914001F4A03 /* Icon.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Icon.swift; sourceTree = "<group>"; };
 		653A254D283387FE005D4D48 /* ENGAGEHF.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ENGAGEHF.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		653A2550283387FE005D4D48 /* ENGAGEHF.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ENGAGEHF.swift; sourceTree = "<group>"; };
 		653A255428338800005D4D48 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -566,6 +570,7 @@
 				4D0F38A12C0A7AD900DA12F7 /* ExpandableText.swift */,
 				2117554C2CC1D39900A81E24 /* ExpandableSection.swift */,
 				4D9D43662C59A88C000062D3 /* ExpandableListCard.swift */,
+				6504AFF72D403914001F4A03 /* Icon.swift */,
 			);
 			path = ReusableElements;
 			sourceTree = "<group>";
@@ -1062,6 +1067,14 @@
 			path = MessageManager;
 			sourceTree = "<group>";
 		};
+		6504AFF42D403803001F4A03 /* StudyConcluded */ = {
+			isa = PBXGroup;
+			children = (
+				6504AFF52D40382F001F4A03 /* StudyConcluded.swift */,
+			);
+			path = StudyConcluded;
+			sourceTree = "<group>";
+		};
 		653A2544283387FE005D4D48 = {
 			isa = PBXGroup;
 			children = (
@@ -1096,6 +1109,7 @@
 				4D9D43542C596CED000062D3 /* SharedExtensions */,
 				4D065BDE2C093FF600EBB3AE /* ReusableElements */,
 				4D081A212C6C2BCB00E13BC8 /* Managers */,
+				6504AFF42D403803001F4A03 /* StudyConcluded */,
 				4DF370062C66C9FF004D737A /* HealthSummary */,
 				4DF36FFB2C66A8ED004D737A /* Questionnaire */,
 				4D8402862C5023E100817495 /* Medications */,
@@ -1440,6 +1454,7 @@
 				4D40A4D22C5B0AB2003DC813 /* VideoList.swift in Sources */,
 				4D4670CC2C79408C004DEAC4 /* VitalsGraph+GraphHeader.swift in Sources */,
 				4DF5063A2C2F5104003E7EFB /* DisplayMeasurement.swift in Sources */,
+				6504AFF62D40383F001F4A03 /* StudyConcluded.swift in Sources */,
 				4D73A5192C581C2300CCEC46 /* CurrentLabelSizeKey.swift in Sources */,
 				4DC990582C7D148B001E86C5 /* ClosedRange+Extend.swift in Sources */,
 				4D4072842C46DDB2007C5621 /* VitalsGraph+ViewModel.swift in Sources */,
@@ -1496,6 +1511,7 @@
 				4D2D1D602C2B859C00ABDC19 /* GraphPicker.swift in Sources */,
 				4D8402DE2C5417F400817495 /* MedicationDescription.swift in Sources */,
 				9B1864942C9276C40042AC81 /* AuthFlow.swift in Sources */,
+				6504AFF82D403914001F4A03 /* Icon.swift in Sources */,
 				213AD98D2CBDF74A005C6D69 /* MedicationsSection.swift in Sources */,
 				4DBDD3462BBFAE2D001FB0CA /* InvitationCodeView.swift in Sources */,
 				4D40A4B62C5AA094003DC813 /* VideoView.swift in Sources */,

--- a/ENGAGEHF/Account/AccountDisabled.swift
+++ b/ENGAGEHF/Account/AccountDisabled.swift
@@ -1,0 +1,22 @@
+//
+// This source file is part of the ENGAGE-HF project based on the Stanford Spezi Template Application project
+//
+// SPDX-FileCopyrightText: 2024 Stanford University
+//
+// SPDX-License-Identifier: MIT
+//
+
+import Foundation
+import SpeziAccount
+
+
+extension AccountDetails {
+    /// If a user account has been disabled by the study coordinator.
+    @AccountKey(name: LocalizedStringResource("Account Disabled"), as: Bool.self)
+    public var disabled: Bool? // swiftlint:disable:this attributes discouraged_optional_boolean
+
+}
+
+
+@KeyEntry(\.disabled)
+extension AccountKeys {}

--- a/ENGAGEHF/Account/AccountSheet.swift
+++ b/ENGAGEHF/Account/AccountSheet.swift
@@ -35,6 +35,18 @@ struct AccountSheet: View {
         }
 }
 
+#Preview("AccountSheet Disabled") {
+    var details = AccountDetails()
+    details.userId = "lelandstanford@stanford.edu"
+    details.name = PersonNameComponents(givenName: "Leland", familyName: "Stanford")
+    details.disabled = true
+
+    return AccountSheet()
+        .previewWith {
+            AccountConfiguration(service: InMemoryAccountService(), activeDetails: details)
+        }
+}
+
 #Preview("AccountSheet SignIn") {
     AccountSheet()
         .previewWith {

--- a/ENGAGEHF/Account/AdditionalAccountSections.swift
+++ b/ENGAGEHF/Account/AdditionalAccountSections.swift
@@ -6,6 +6,7 @@
 // SPDX-License-Identifier: MIT
 //
 
+@_spi(TestingSupport) import SpeziAccount
 import SpeziBluetooth
 import SpeziDevicesUI
 import SpeziLicense
@@ -13,22 +14,27 @@ import SwiftUI
 
 
 struct AdditionalAccountSections: View {
+    @Environment(Account.self) private var account: Account?
+    
+    
     var body: some View {
         Section {
-            NavigationLink {
-                HealthSummaryView()
-            } label: {
-                Text("Health Summary")
-            }
-            NavigationLink {
-                Contacts()
-            } label: {
-                Text("Contacts")
-            }
-            NavigationLink {
-                NotificationSettingsView()
-            } label: {
-                Text("Notifications")
+            if !(account?.details?.disabled ?? false) {
+                NavigationLink {
+                    HealthSummaryView()
+                } label: {
+                    Text("Health Summary")
+                }
+                NavigationLink {
+                    Contacts()
+                } label: {
+                    Text("Contacts")
+                }
+                NavigationLink {
+                    NotificationSettingsView()
+                } label: {
+                    Text("Notifications")
+                }
             }
             NavigationLink {
                 NavigationStack {
@@ -47,6 +53,18 @@ struct AdditionalAccountSections: View {
             } label: {
                 Text("LICENSE_INFO_TITLE")
             }
+        }
+    }
+}
+
+
+#Preview {
+    NavigationStack {
+        List {
+            AdditionalAccountSections()
+                .previewWith(standard: ENGAGEHFStandard()) {
+                    AccountConfiguration(service: InMemoryAccountService())
+                }
         }
     }
 }

--- a/ENGAGEHF/ContentView.swift
+++ b/ENGAGEHF/ContentView.swift
@@ -47,11 +47,7 @@ struct ContentView: View {
             if account?.signedIn ?? false {
                 HomeView()
             } else {
-                Image(.engagehfIcon)
-                    .resizable()
-                    .scaledToFit()
-                    .frame(width: 128, height: 128)
-                    .clipShape(RoundedRectangle(cornerRadius: 32))
+                Icon()
                     .accessibilityLabel("ENGAGE-HF Application Loading Screen")
             }
         }

--- a/ENGAGEHF/Dashboard/Dashboard.swift
+++ b/ENGAGEHF/Dashboard/Dashboard.swift
@@ -6,6 +6,7 @@
 // SPDX-License-Identifier: MIT
 //
 
+@_spi(TestingSupport) import SpeziAccount
 @_spi(TestingSupport) import SpeziDevices
 import SwiftUI
 
@@ -63,6 +64,7 @@ struct Dashboard: View {
 #Preview {
     Dashboard(presentingAccount: .constant(false))
         .previewWith(standard: ENGAGEHFStandard()) {
+            AccountConfiguration(service: InMemoryAccountService())
             MessageManager()
             HealthMeasurements(mock: [.weight(.mockWeighSample)])
             VitalsManager()

--- a/ENGAGEHF/ENGAGEHFDelegate.swift
+++ b/ENGAGEHF/ENGAGEHFDelegate.swift
@@ -57,7 +57,8 @@ class ENGAGEHFDelegate: SpeziAppDelegate {
                         .manual(\.receivesQuestionnaireReminders),
                         .manual(\.receivesRecommendationUpdates),
                         .manual(\.receivesVitalsReminders),
-                        .manual(\.receivesWeightAlerts)
+                        .manual(\.receivesWeightAlerts),
+                        .manual(\.disabled)
                     ]
                 )
                 

--- a/ENGAGEHF/Home.swift
+++ b/ENGAGEHF/Home.swift
@@ -29,6 +29,7 @@ struct HomeView: View {
     @Environment(ENGAGEHFStandard.self) private var standard
     @Environment(NavigationManager.self) private var navigationManager
     @Environment(NotificationManager.self) private var notificationManager
+    @Environment(Account.self) private var account: Account?
     
     @State private var presentingAccount = false
     
@@ -38,27 +39,33 @@ struct HomeView: View {
         @Bindable var navigationManager = navigationManager
         @Bindable var notificationManager = notificationManager
 
-        TabView(selection: $navigationManager.selectedTab) {
-            Dashboard(presentingAccount: $presentingAccount)
-                .tag(Tabs.home)
-                .tabItem {
-                    Label("Home", systemImage: "house")
+        Group {
+            if account?.details?.disabled ?? false {
+                StudyConcluded(presentingAccount: $presentingAccount)
+            } else {
+                TabView(selection: $navigationManager.selectedTab) {
+                    Dashboard(presentingAccount: $presentingAccount)
+                        .tag(Tabs.home)
+                        .tabItem {
+                            Label("Home", systemImage: "house")
+                        }
+                    HeartHealth(presentingAccount: $presentingAccount)
+                        .tag(Tabs.heart)
+                        .tabItem {
+                            Label("Heart Health", systemImage: "heart")
+                        }
+                    Medications(presentingAccount: $presentingAccount)
+                        .tag(Tabs.medications)
+                        .tabItem {
+                            Label("Medications", systemImage: "pill.fill")
+                        }
+                    Education(presentingAccount: $presentingAccount)
+                        .tag(Tabs.education)
+                        .tabItem {
+                            Label("Education", systemImage: "brain")
+                        }
                 }
-            HeartHealth(presentingAccount: $presentingAccount)
-                .tag(Tabs.heart)
-                .tabItem {
-                    Label("Heart Health", systemImage: "heart")
-                }
-            Medications(presentingAccount: $presentingAccount)
-                .tag(Tabs.medications)
-                .tabItem {
-                    Label("Medications", systemImage: "pill.fill")
-                }
-            Education(presentingAccount: $presentingAccount)
-                .tag(Tabs.education)
-                .tabItem {
-                    Label("Education", systemImage: "brain")
-                }
+            }
         }
             .sheet(isPresented: $navigationManager.showHealthSummary) {
                 HealthSummaryView()
@@ -80,12 +87,8 @@ struct HomeView: View {
 
 
 #if DEBUG
-#Preview {
-    var details = AccountDetails()
-    details.userId = "lelandstanford@stanford.edu"
-    details.name = PersonNameComponents(givenName: "Leland", familyName: "Stanford")
-
-    return HomeView()
+#Preview("Home") {
+    HomeView()
         .previewWith(standard: ENGAGEHFStandard()) {
             AccountConfiguration(service: InMemoryAccountService())
             HealthMeasurements()
@@ -97,6 +100,22 @@ struct HomeView: View {
             NavigationManager()
             VideoManager()
             MedicationsManager()
+            NotificationManager()
+        }
+}
+
+#Preview("Home - Disabled") {
+    var details = AccountDetails()
+    details.userId = "lelandstanford@stanford.edu"
+    details.name = PersonNameComponents(givenName: "Leland", familyName: "Stanford")
+    details.disabled = true
+
+    return HomeView()
+        .previewWith(standard: ENGAGEHFStandard()) {
+            AccountConfiguration(service: InMemoryAccountService(), activeDetails: details)
+            HealthMeasurements()
+            NavigationManager()
+            NotificationManager()
         }
 }
 #endif

--- a/ENGAGEHF/Resources/Localizable.xcstrings
+++ b/ENGAGEHF/Resources/Localizable.xcstrings
@@ -43,6 +43,9 @@
     "About %@" : {
 
     },
+    "Account Disabled" : {
+
+    },
     "ACCOUNT_NEXT" : {
       "localizations" : {
         "en" : {
@@ -185,7 +188,13 @@
     "Enable Notifications in Settings" : {
 
     },
+    "ENGAGE-HF" : {
+
+    },
     "ENGAGE-HF Application Loading Screen" : {
+
+    },
+    "ENGAGE-HF Icon" : {
 
     },
     "Expansion Button" : {
@@ -641,6 +650,9 @@
     "Target" : {
 
     },
+    "Thank you for participating in the ENGAGE-HF Study!" : {
+
+    },
     "The invitation code is invalid or has already been used." : {
       "comment" : "Invitation Code Invalid"
     },
@@ -845,6 +857,9 @@
     },
     "You are on your target dose." : {
       "comment" : "Target dose reached color legend entry."
+    },
+    "Your account was deactivated by the study coordinator." : {
+
     }
   },
   "version" : "1.0"

--- a/ENGAGEHF/ReusableElements/Icon.swift
+++ b/ENGAGEHF/ReusableElements/Icon.swift
@@ -1,0 +1,26 @@
+//
+// This source file is part of the ENGAGE-HF project based on the Stanford Spezi Template Application project
+//
+// SPDX-FileCopyrightText: 2023 Stanford University
+//
+// SPDX-License-Identifier: MIT
+//
+
+import SwiftUI
+
+
+struct Icon: View {
+    var body: some View {
+        Image(.engagehfIcon)
+            .resizable()
+            .scaledToFit()
+            .frame(width: 128, height: 128)
+            .clipShape(RoundedRectangle(cornerRadius: 32))
+            .accessibilityLabel("ENGAGE-HF Icon")
+    }
+}
+
+
+#Preview {
+    Icon()
+}

--- a/ENGAGEHF/StudyConcluded/StudyConcluded.swift
+++ b/ENGAGEHF/StudyConcluded/StudyConcluded.swift
@@ -1,0 +1,50 @@
+//
+// This source file is part of the ENGAGE-HF project based on the Stanford Spezi Template Application project
+//
+// SPDX-FileCopyrightText: 2023 Stanford University
+//
+// SPDX-License-Identifier: MIT
+//
+
+@_spi(TestingSupport) import SpeziAccount
+import SwiftUI
+
+
+struct StudyConcluded: View {
+    @Binding var presentingAccount: Bool
+    
+    
+    var body: some View {
+        NavigationStack {
+            VStack(alignment: .center) {
+                Icon()
+                    .padding()
+                Text(
+                    """
+                    Thank you for participating in the ENGAGE-HF Study!
+                    """
+                )
+                    .multilineTextAlignment(.center)
+            }
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .padding()
+                .background(Color(.systemGroupedBackground))
+                .navigationTitle("ENGAGE-HF")
+                .toolbar {
+                    if AccountButton.shouldDisplay {
+                        AccountButton(isPresented: $presentingAccount)
+                    }
+                }
+        }
+    }
+}
+
+
+#if DEBUG
+#Preview {
+    StudyConcluded(presentingAccount: .constant(false))
+        .previewWith(standard: ENGAGEHFStandard()) {
+            AccountConfiguration(service: InMemoryAccountService())
+        }
+}
+#endif

--- a/ENGAGEHF/StudyConcluded/StudyConcluded.swift
+++ b/ENGAGEHF/StudyConcluded/StudyConcluded.swift
@@ -16,16 +16,15 @@ struct StudyConcluded: View {
     
     var body: some View {
         NavigationStack {
-            VStack(alignment: .center) {
+            VStack(alignment: .center, spacing: 16) {
                 Icon()
                     .padding()
-                Text(
-                    """
-                    Thank you for participating in the ENGAGE-HF Study!
-                    """
-                )
-                    .multilineTextAlignment(.center)
+                Text("Thank you for participating in the\nENGAGE-HF study!")
+                Text("Your account was deactivated\nby your study coordinator.")
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
             }
+                .multilineTextAlignment(.center)
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
                 .padding()
                 .background(Color(.systemGroupedBackground))

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -195,6 +195,8 @@ platform :ios do
       upload_to_testflight(
         app_identifier: appidentifier,
         distribute_external: true,
+        reject_build_waiting_for_review: true,
+        expire_previous_builds: true,
         groups: [
           "External Testers"
         ],


### PR DESCRIPTION
# Study Finished Screen

## :gear: Release Notes 
- Adds a Study Finished Screen to the ENGAGE-HF app.
<img width="256" alt="Screenshot 2025-01-21 at 11 06 27 PM" src="https://github.com/user-attachments/assets/ca5f0ff5-8ba2-4158-8014-033036d0aa0b" />


### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).
