### PR TITLE
Add QR Code Sharing View for Health Summary

### DIFF
--- a/ENGAGEHF.xcodeproj/project.pbxproj
+++ b/ENGAGEHF.xcodeproj/project.pbxproj
@@ -196,6 +196,7 @@
 		4DF506312C2F3421003E7EFB /* VitalsGraph.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DF506302C2F3421003E7EFB /* VitalsGraph.swift */; };
 		4DF5063A2C2F5104003E7EFB /* DisplayMeasurement.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DF506392C2F5104003E7EFB /* DisplayMeasurement.swift */; };
 		562E7C222D8039630088D8DF /* QRCodeShareView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 562E7C212D8039630088D8DF /* QRCodeShareView.swift */; };
+		5681F6C62D9292F90071EA5D /* HealthSummaryUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5681F6C52D9292ED0071EA5D /* HealthSummaryUITests.swift */; };
 		56E708352BB06B7100B08F0A /* SpeziLicense in Frameworks */ = {isa = PBXBuildFile; productRef = 56E708342BB06B7100B08F0A /* SpeziLicense */; };
 		56E7083B2BB06F6F00B08F0A /* SwiftPackageList in Frameworks */ = {isa = PBXBuildFile; productRef = 56E7083A2BB06F6F00B08F0A /* SwiftPackageList */; };
 		6504AFF62D40383F001F4A03 /* StudyConcluded.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6504AFF52D40382F001F4A03 /* StudyConcluded.swift */; };
@@ -419,6 +420,7 @@
 		4DF506302C2F3421003E7EFB /* VitalsGraph.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VitalsGraph.swift; sourceTree = "<group>"; };
 		4DF506392C2F5104003E7EFB /* DisplayMeasurement.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DisplayMeasurement.swift; sourceTree = "<group>"; };
 		562E7C212D8039630088D8DF /* QRCodeShareView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QRCodeShareView.swift; sourceTree = "<group>"; };
+		5681F6C52D9292ED0071EA5D /* HealthSummaryUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HealthSummaryUITests.swift; sourceTree = "<group>"; };
 		6504AFF52D40382F001F4A03 /* StudyConcluded.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StudyConcluded.swift; sourceTree = "<group>"; };
 		6504AFF72D403914001F4A03 /* Icon.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Icon.swift; sourceTree = "<group>"; };
 		6504B0022D40C8BF001F4A03 /* AccountDisabled.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountDisabled.swift; sourceTree = "<group>"; };
@@ -956,6 +958,7 @@
 		4DD5FC572C87B4980051E6F5 /* Account */ = {
 			isa = PBXGroup;
 			children = (
+				5681F6C52D9292ED0071EA5D /* HealthSummaryUITests.swift */,
 				4D4AA0A42BC5E43E00676489 /* OnboardingUITests.swift */,
 				A9F2138D2C18EBAB00A7578F /* AccountTests.swift */,
 				4D8CE1022C7568C700560327 /* ContactsUITests.swift */,
@@ -1559,6 +1562,7 @@
 				4D335C932C628F5600C720B5 /* EducationViewUITests.swift in Sources */,
 				4DD823062C17FF79004DC599 /* MessagesUITests.swift in Sources */,
 				2F4E237E2989A2FE0013F3D9 /* LaunchTests.swift in Sources */,
+				5681F6C62D9292F90071EA5D /* HealthSummaryUITests.swift in Sources */,
 				4DB025CA2BBE3A59002D2545 /* HomeViewUITests.swift in Sources */,
 				4D8402842C4F11CB00817495 /* XCUIApplication+DeleteMeasurements.swift in Sources */,
 				4D8402772C4EE52000817495 /* AddMeasurementUITests.swift in Sources */,

--- a/ENGAGEHF.xcodeproj/project.pbxproj
+++ b/ENGAGEHF.xcodeproj/project.pbxproj
@@ -195,6 +195,7 @@
 		4DF5062F2C2F2B00003E7EFB /* SymptomsPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DF5062E2C2F2B00003E7EFB /* SymptomsPicker.swift */; };
 		4DF506312C2F3421003E7EFB /* VitalsGraph.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DF506302C2F3421003E7EFB /* VitalsGraph.swift */; };
 		4DF5063A2C2F5104003E7EFB /* DisplayMeasurement.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DF506392C2F5104003E7EFB /* DisplayMeasurement.swift */; };
+		562E7C222D8039630088D8DF /* QRCodeShareView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 562E7C212D8039630088D8DF /* QRCodeShareView.swift */; };
 		56E708352BB06B7100B08F0A /* SpeziLicense in Frameworks */ = {isa = PBXBuildFile; productRef = 56E708342BB06B7100B08F0A /* SpeziLicense */; };
 		56E7083B2BB06F6F00B08F0A /* SwiftPackageList in Frameworks */ = {isa = PBXBuildFile; productRef = 56E7083A2BB06F6F00B08F0A /* SwiftPackageList */; };
 		6504AFF62D40383F001F4A03 /* StudyConcluded.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6504AFF52D40382F001F4A03 /* StudyConcluded.swift */; };
@@ -417,6 +418,7 @@
 		4DF5062E2C2F2B00003E7EFB /* SymptomsPicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SymptomsPicker.swift; sourceTree = "<group>"; };
 		4DF506302C2F3421003E7EFB /* VitalsGraph.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VitalsGraph.swift; sourceTree = "<group>"; };
 		4DF506392C2F5104003E7EFB /* DisplayMeasurement.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DisplayMeasurement.swift; sourceTree = "<group>"; };
+		562E7C212D8039630088D8DF /* QRCodeShareView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QRCodeShareView.swift; sourceTree = "<group>"; };
 		6504AFF52D40382F001F4A03 /* StudyConcluded.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StudyConcluded.swift; sourceTree = "<group>"; };
 		6504AFF72D403914001F4A03 /* Icon.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Icon.swift; sourceTree = "<group>"; };
 		6504B0022D40C8BF001F4A03 /* AccountDisabled.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountDisabled.swift; sourceTree = "<group>"; };
@@ -1038,6 +1040,7 @@
 				4DF370032C66C9F9004D737A /* HealthSummaryView.swift */,
 				4DF370072C66CAC9004D737A /* PDFViewer.swift */,
 				4DF3700C2C66E479004D737A /* PDFDocument+Transferable.swift */,
+				562E7C212D8039630088D8DF /* QRCodeShareView.swift */,
 			);
 			path = HealthSummary;
 			sourceTree = "<group>";
@@ -1436,6 +1439,7 @@
 				4D4072972C484716007C5621 /* VitalsGraph+VitalsGraphContent.swift in Sources */,
 				4DF506282C2F2598003E7EFB /* VitalsContentView.swift in Sources */,
 				4D40728F2C483A5C007C5621 /* VitalsGraph+GestureOverlay.swift in Sources */,
+				562E7C222D8039630088D8DF /* QRCodeShareView.swift in Sources */,
 				4D92B9F82C3C901500ABCED7 /* SymptomsGraphSection.swift in Sources */,
 				4DC9905D2C7D1C98001E86C5 /* Double+Rounding.swift in Sources */,
 				4DF36FF52C667D39004D737A /* AnyAxisContent+CustomAxes.swift in Sources */,

--- a/ENGAGEHF.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ENGAGEHF.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "49f71d3f232f37193b58998d85e7e5244bc482d675480e41c8c084f5b7e068f5",
+  "originHash" : "759b5b442d547635957ae0aecf41ebdbfdd51c12c31492ed125bcf4000e9bec1",
   "pins" : [
     {
       "identity" : "abseil-cpp-binary",
@@ -184,10 +184,10 @@
     {
       "identity" : "spezi",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/StanfordSpezi/Spezi",
+      "location" : "https://github.com/StanfordSpezi/Spezi.git",
       "state" : {
-        "revision" : "4513a697572e8e1faea1e0ee52e6fad4b8d3dd8d",
-        "version" : "1.8.0"
+        "revision" : "49ed1ddcfb7d0f753990b55578c33a887513fb39",
+        "version" : "1.8.1"
       }
     },
     {
@@ -204,8 +204,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/StanfordSpezi/SpeziBluetooth.git",
       "state" : {
-        "revision" : "e2600a2fd0b8c59513ac0b549785b123c1508894",
-        "version" : "3.2.0"
+        "revision" : "f6b958107ef1a1ae18d2e1f449ace74191c62d9e",
+        "version" : "3.2.1"
       }
     },
     {
@@ -245,18 +245,9 @@
       }
     },
     {
-      "identity" : "spezihealthkit",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/StanfordSpezi/SpeziHealthKit.git",
-      "state" : {
-        "revision" : "1e9cb5a6036ac7f4ff37ea1c3ed4898103339ad1",
-        "version" : "0.5.3"
-      }
-    },
-    {
       "identity" : "spezilicense",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/StanfordSpezi/SpeziLicense",
+      "location" : "https://github.com/StanfordSpezi/SpeziLicense.git",
       "state" : {
         "revision" : "2249ce615a624a072834e31e7906b779ba82b824",
         "version" : "0.1.1"
@@ -265,10 +256,10 @@
     {
       "identity" : "spezinetworking",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/StanfordSpezi/SpeziNetworking",
+      "location" : "https://github.com/StanfordSpezi/SpeziNetworking.git",
       "state" : {
-        "revision" : "89fad797897bb741fc148027859c1bab3129999a",
-        "version" : "2.2.0"
+        "revision" : "098e78d7717fc4e3199c579e47c75b916ce678ca",
+        "version" : "2.3.0"
       }
     },
     {
@@ -283,7 +274,7 @@
     {
       "identity" : "spezionboarding",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/StanfordSpezi/SpeziOnboarding",
+      "location" : "https://github.com/StanfordSpezi/SpeziOnboarding.git",
       "state" : {
         "revision" : "a3d7bc15e6803b2205eb8dca010a48b1a40215be",
         "version" : "1.2.2"
@@ -366,8 +357,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-numerics.git",
       "state" : {
-        "revision" : "0a5bc04095a675662cf24757cc0640aa2204253b",
-        "version" : "1.0.2"
+        "revision" : "e0ec0f5f3af6f3e4d5e7a19d2af26b481acb6ba8",
+        "version" : "1.0.3"
       }
     },
     {
@@ -447,8 +438,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/StanfordBDHG/XCTHealthKit.git",
       "state" : {
-        "revision" : "9353b5fea249a73e9b35761bd781c63c02088203",
-        "version" : "1.1.1"
+        "revision" : "550a6f5feb05d8b08a4f4a1c512701f4622bd2d4",
+        "version" : "1.1.2"
       }
     },
     {

--- a/ENGAGEHF/HealthSummary/HealthSummaryView.swift
+++ b/ENGAGEHF/HealthSummary/HealthSummaryView.swift
@@ -95,7 +95,7 @@ struct HealthSummaryView: View {
                 ShareLink(
                     // swiftlint:disable:next force_unwrapping
                     item: URL(string: url)!,
-                    preview: SharePreview("Health Summary", image: Image(.engagehfIcon))
+                    preview: SharePreview("Health Summary Link", image: Image(.engagehfIcon))
                 )
                 .accessibilityLabel("Share Link")
             }

--- a/ENGAGEHF/HealthSummary/HealthSummaryView.swift
+++ b/ENGAGEHF/HealthSummary/HealthSummaryView.swift
@@ -84,7 +84,7 @@ struct HealthSummaryView: View {
     
     private var shareModeSelector: some ToolbarContent {
         ToolbarItem(placement: .principal) {
-            Picker("?", selection: $shareState) {
+            Picker("Health Summary Share Mode", selection: $shareState) {
                 Text("PDF").tag(ShareState.pdf)
                 Text("QR Code").tag(ShareState.qrCode)
             }

--- a/ENGAGEHF/HealthSummary/HealthSummaryView.swift
+++ b/ENGAGEHF/HealthSummary/HealthSummaryView.swift
@@ -22,7 +22,6 @@ struct HealthSummaryView: View {
     
     @State private var healthSummaryDocument: PDFDocument?
     @State private var viewState: ViewState = .idle
-    @State private var fullUrl: String?
     @State private var url: String?
     @State private var code: String?
     @State private var timeRemaining: Int?
@@ -73,8 +72,8 @@ struct HealthSummaryView: View {
     
     private var qrCodeView: some View {
         ZStack {
-            if let fullUrl, let code, let timeRemaining {
-                QRCodeShareView(url: fullUrl, code: code, timeRemaining: timeRemaining)
+            if let url, let code, let timeRemaining {
+                QRCodeShareView(url: url, code: code, timeRemaining: timeRemaining)
             } else {
                 ProgressView("Generating QR Code")
             }
@@ -149,7 +148,6 @@ struct HealthSummaryView: View {
             let result = try await shareHealthSummary.call([ "userId": userId ] )
             
             let dataDictionary = result.data as? [String: Any]
-            self.fullUrl = dataDictionary?["fullUrl"] as? String
             self.url = dataDictionary?["url"] as? String
             self.code = dataDictionary?["code"] as? String
             if let expiresAtString = dataDictionary?["expiresAt"] as? String {

--- a/ENGAGEHF/HealthSummary/QRCodeShareView.swift
+++ b/ENGAGEHF/HealthSummary/QRCodeShareView.swift
@@ -48,6 +48,7 @@ struct QRCodeShareView: View {
                             Spacer()
                             Text(code.uppercased())
                                 .font(.body.monospaced())
+                                .textSelection(.enabled)
                         }
                     }
                 }

--- a/ENGAGEHF/HealthSummary/QRCodeShareView.swift
+++ b/ENGAGEHF/HealthSummary/QRCodeShareView.swift
@@ -1,0 +1,61 @@
+//
+// This source file is part of the ENGAGE-HF project based on the Stanford Spezi Template Application project
+//
+// SPDX-FileCopyrightText: 2023 Stanford University
+//
+// SPDX-License-Identifier: MIT
+//
+
+import CoreImage.CIFilterBuiltins
+import SwiftUI
+
+
+struct QRCodeShareView: View {
+    let url: String
+    let code: String
+    let context = CIContext()
+    let filter = CIFilter.qrCodeGenerator()
+    
+    
+    var body: some View {
+        VStack {
+            GroupBox(label: Text("Health Summary QR Code")) {
+                Text("This QR code can be scanned by your doctor to share your health summary.")
+                    .padding(.top)
+                Image(uiImage: generateQRCode(from: url))
+                    .interpolation(.none)
+                    .resizable()
+                    .scaledToFit()
+                    .frame(width: 200, height: 200)
+                    .padding()
+                    .accessibilityLabel("QR code for sharing your health summary with your doctor")
+                GroupBox {
+                    HStack {
+                        Text("One-time Code")
+                        Spacer()
+                        Text(code.uppercased())
+                    }
+                }
+            }
+                .padding()
+            Spacer()
+        }
+    }
+    
+    
+    private func generateQRCode(from string: String) -> UIImage {
+        filter.message = Data(string.utf8)
+
+        if let outputImage = filter.outputImage {
+            if let cgImage = context.createCGImage(outputImage, from: outputImage.extent) {
+                return UIImage(cgImage: cgImage)
+            }
+        }
+
+        return UIImage(systemName: "xmark.circle") ?? UIImage()
+    }
+}
+
+#Preview {
+    QRCodeShareView(url: "/example-link", code: "1111")
+}

--- a/ENGAGEHF/HealthSummary/QRCodeShareView.swift
+++ b/ENGAGEHF/HealthSummary/QRCodeShareView.swift
@@ -7,6 +7,7 @@
 //
 
 import CoreImage.CIFilterBuiltins
+import SpeziViews
 import SwiftUI
 
 
@@ -26,7 +27,6 @@ struct QRCodeShareView: View {
                     Text("This QR code can be scanned by your healthcare provider to share your health summary.")
                     VStack {
                         Text("Expires in: \(Int(timeRemaining) / 60):\(String(format: "%02d", Int(timeRemaining) % 60))")
-                            .font(.callout)
                             .foregroundStyle(.secondary)
                         if let image = qrCodeImage {
                             Image(uiImage: image)
@@ -36,6 +36,8 @@ struct QRCodeShareView: View {
                                 .frame(maxWidth: .infinity)
                                 .clipShape(RoundedRectangle(cornerRadius: 10))
                                 .accessibilityLabel("QR code for sharing your health summary with your doctor")
+                        } else {
+                            qrCodePlaceholderView
                         }
                     }
                         .padding(.top)
@@ -63,7 +65,18 @@ struct QRCodeShareView: View {
                 UIScreen.main.brightness = originalBrightness
             }
     }
-       
+    
+    
+    private var qrCodePlaceholderView: some View {
+        RoundedRectangle(cornerRadius: 10)
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .aspectRatio(1, contentMode: .fit)
+            .foregroundColor(.white)
+            .overlay(
+                ProgressView()
+                    .scaleEffect(1.5)
+            )
+    }
     
     private func generateQRCode(from string: String) -> UIImage {
         let context = CIContext()

--- a/ENGAGEHF/HealthSummary/QRCodeShareView.swift
+++ b/ENGAGEHF/HealthSummary/QRCodeShareView.swift
@@ -11,8 +11,11 @@ import SwiftUI
 
 
 struct QRCodeShareView: View {
+    @State private var originalBrightness: CGFloat = UIScreen.main.brightness
+    
     let url: String
     let code: String
+    let timeRemaining: Int
     let context = CIContext()
     let filter = CIFilter.qrCodeGenerator()
     
@@ -20,29 +23,43 @@ struct QRCodeShareView: View {
     var body: some View {
         VStack {
             GroupBox(label: Text("Health Summary QR Code")) {
-                Text("This QR code can be scanned by your doctor to share your health summary.")
-                    .padding(.top)
-                Image(uiImage: generateQRCode(from: url))
-                    .interpolation(.none)
-                    .resizable()
-                    .scaledToFit()
-                    .frame(width: 200, height: 200)
-                    .padding()
-                    .accessibilityLabel("QR code for sharing your health summary with your doctor")
-                GroupBox {
-                    HStack {
-                        Text("One-time Code")
-                            .bold()
-                        Spacer()
-                        Text(code.uppercased())
+                VStack(alignment: .leading) {
+                    Text("This QR code can be scanned by your doctor to share your health summary.")
+                    VStack {
+                        Text("Expires in: \(Int(timeRemaining) / 60):\(String(format: "%02d", Int(timeRemaining) % 60))")
+                            .font(.callout)
+                            .foregroundStyle(.secondary)
+                        Image(uiImage: generateQRCode(from: url))
+                            .interpolation(.none)
+                            .resizable()
+                            .scaledToFit()
+                            .frame(maxWidth: .infinity)
+                            .clipShape(RoundedRectangle(cornerRadius: 10))
+                            .accessibilityLabel("QR code for sharing your health summary with your doctor")
+                    }
+                        .padding(.top)
+                    GroupBox {
+                        HStack {
+                            Text("One-time Code")
+                                .bold()
+                            Spacer()
+                            Text(code.uppercased())
+                                .font(.body.monospaced())
+                        }
                     }
                 }
             }
                 .padding()
             Spacer()
         }
+            .onAppear {
+                UIScreen.main.brightness = 1.0
+            }
+            .onDisappear {
+                UIScreen.main.brightness = originalBrightness
+            }
     }
-    
+       
     
     private func generateQRCode(from string: String) -> UIImage {
         filter.message = Data(string.utf8)
@@ -58,5 +75,5 @@ struct QRCodeShareView: View {
 }
 
 #Preview {
-    QRCodeShareView(url: "/example-link", code: "1111")
+    QRCodeShareView(url: "/example-link", code: "1111", timeRemaining: 10)
 }

--- a/ENGAGEHF/HealthSummary/QRCodeShareView.swift
+++ b/ENGAGEHF/HealthSummary/QRCodeShareView.swift
@@ -32,6 +32,7 @@ struct QRCodeShareView: View {
                 GroupBox {
                     HStack {
                         Text("One-time Code")
+                            .bold()
                         Spacer()
                         Text(code.uppercased())
                     }

--- a/ENGAGEHF/HealthSummary/QRCodeShareView.swift
+++ b/ENGAGEHF/HealthSummary/QRCodeShareView.swift
@@ -12,6 +12,7 @@ import SwiftUI
 
 struct QRCodeShareView: View {
     @State private var originalBrightness: CGFloat = UIScreen.main.brightness
+    @State private var qrCodeImage: UIImage?
     
     let url: String
     let code: String
@@ -29,13 +30,15 @@ struct QRCodeShareView: View {
                         Text("Expires in: \(Int(timeRemaining) / 60):\(String(format: "%02d", Int(timeRemaining) % 60))")
                             .font(.callout)
                             .foregroundStyle(.secondary)
-                        Image(uiImage: generateQRCode(from: url))
-                            .interpolation(.none)
-                            .resizable()
-                            .scaledToFit()
-                            .frame(maxWidth: .infinity)
-                            .clipShape(RoundedRectangle(cornerRadius: 10))
-                            .accessibilityLabel("QR code for sharing your health summary with your doctor")
+                        if let image = qrCodeImage {
+                            Image(uiImage: image)
+                                .interpolation(.none)
+                                .resizable()
+                                .scaledToFit()
+                                .frame(maxWidth: .infinity)
+                                .clipShape(RoundedRectangle(cornerRadius: 10))
+                                .accessibilityLabel("QR code for sharing your health summary with your doctor")
+                        }
                     }
                         .padding(.top)
                     GroupBox {
@@ -52,6 +55,9 @@ struct QRCodeShareView: View {
                 .padding()
             Spacer()
         }
+            .task(id: url) {
+                qrCodeImage = generateQRCode(from: url)
+            }
             .onAppear {
                 UIScreen.main.brightness = 1.0
             }

--- a/ENGAGEHF/HealthSummary/QRCodeShareView.swift
+++ b/ENGAGEHF/HealthSummary/QRCodeShareView.swift
@@ -17,8 +17,6 @@ struct QRCodeShareView: View {
     let url: String
     let code: String
     let timeRemaining: Int
-    let context = CIContext()
-    let filter = CIFilter.qrCodeGenerator()
     
     
     var body: some View {
@@ -68,6 +66,9 @@ struct QRCodeShareView: View {
        
     
     private func generateQRCode(from string: String) -> UIImage {
+        let context = CIContext()
+        let filter = CIFilter.qrCodeGenerator()
+        
         filter.message = Data(string.utf8)
 
         if let outputImage = filter.outputImage {

--- a/ENGAGEHF/Resources/Localizable.xcstrings
+++ b/ENGAGEHF/Resources/Localizable.xcstrings
@@ -4,9 +4,6 @@
     "" : {
 
     },
-    "?" : {
-
-    },
     "%@ Date: %@" : {
       "localizations" : {
         "en" : {
@@ -203,6 +200,16 @@
     "Expansion Button" : {
 
     },
+    "Expires in: %lld:%@" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Expires in: %1$lld:%2$@"
+          }
+        }
+      }
+    },
     "Failed to fetch HKUnits for the given samples." : {
 
     },
@@ -225,6 +232,9 @@
 
     },
     "Health Summary QR Code" : {
+
+    },
+    "Health Summary Share Mode" : {
 
     },
     "Heart Health" : {

--- a/ENGAGEHF/Resources/Localizable.xcstrings
+++ b/ENGAGEHF/Resources/Localizable.xcstrings
@@ -4,6 +4,9 @@
     "" : {
 
     },
+    "?" : {
+
+    },
     "%@ Date: %@" : {
       "localizations" : {
         "en" : {
@@ -212,10 +215,16 @@
     "Generating Health Summary" : {
 
     },
+    "Generating QR Code" : {
+
+    },
     "Graph Selection" : {
 
     },
     "Health Summary" : {
+
+    },
+    "Health Summary QR Code" : {
 
     },
     "Heart Health" : {
@@ -489,7 +498,13 @@
     "Notifications" : {
 
     },
+    "One-time Code" : {
+
+    },
     "Organization" : {
+
+    },
+    "PDF" : {
 
     },
     "Play Video" : {
@@ -517,6 +532,12 @@
     },
     "Processing..." : {
       "comment" : "Processing state"
+    },
+    "QR Code" : {
+
+    },
+    "QR code for sharing your health summary with your doctor" : {
+
     },
     "Questionnaire Loading" : {
 
@@ -680,6 +701,9 @@
       "comment" : "Invitation Code Invalid"
     },
     "There are currently no educational videos available." : {
+
+    },
+    "This QR code can be scanned by your doctor to share your health summary." : {
 
     },
     "Thumbnail Image: %@" : {

--- a/ENGAGEHF/Resources/Localizable.xcstrings
+++ b/ENGAGEHF/Resources/Localizable.xcstrings
@@ -231,6 +231,9 @@
     "Health Summary" : {
 
     },
+    "Health Summary Link" : {
+
+    },
     "Health Summary QR Code" : {
 
     },

--- a/ENGAGEHF/Resources/Localizable.xcstrings
+++ b/ENGAGEHF/Resources/Localizable.xcstrings
@@ -713,7 +713,7 @@
     "There are currently no educational videos available." : {
 
     },
-    "This QR code can be scanned by your doctor to share your health summary." : {
+    "This QR code can be scanned by your healthcare provider to share your health summary." : {
 
     },
     "Thumbnail Image: %@" : {

--- a/ENGAGEHFUITests/Account/HealthSummaryUITests.swift
+++ b/ENGAGEHFUITests/Account/HealthSummaryUITests.swift
@@ -40,11 +40,11 @@ final class HealthSummaryUITests: XCTestCase {
         XCTAssertTrue(app.segmentedControls.buttons["PDF"].exists)
         XCTAssertTrue(app.segmentedControls.buttons["QR Code"].exists)
         
-        XCTAssertTrue(app.navigationBars.buttons["Share Link"].waitForExistence(timeout: 2))
+        XCTAssertTrue(app.navigationBars.buttons["Share Link"].waitForExistence(timeout: 5))
         
         app.segmentedControls.buttons["QR Code"].tap()
         
-        XCTAssertTrue(app.navigationBars.buttons["Share Link"].waitForExistence(timeout: 2))
+        XCTAssertTrue(app.navigationBars.buttons["Share Link"].waitForExistence(timeout: 5))
         XCTAssertTrue(app.staticTexts["Health Summary QR Code"].waitForExistence(timeout: 5))
         XCTAssertTrue(app.staticTexts["One-time Code"].waitForExistence(timeout: 2))
     }

--- a/ENGAGEHFUITests/Account/HealthSummaryUITests.swift
+++ b/ENGAGEHFUITests/Account/HealthSummaryUITests.swift
@@ -1,0 +1,51 @@
+//
+// This source file is part of the ENGAGE-HF project based on the Stanford Spezi Template Application project
+//
+// SPDX-FileCopyrightText: 2024 Stanford University
+//
+// SPDX-License-Identifier: MIT
+//
+
+import XCTest
+
+final class HealthSummaryUITests: XCTestCase {
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        continueAfterFailure = false
+
+        let app = XCUIApplication()
+        app.launchArguments = [
+            "--assumeOnboardingComplete",
+            "--setupTestEnvironment",
+            "--setupTestUserMetaData",
+            "--useFirebaseEmulator"
+        ]
+        app.launch()
+    }
+
+    
+    func testHealthSummaryView() throws {
+        let app = XCUIApplication()
+        
+        _ = app.staticTexts["Home"].waitForExistence(timeout: 5)
+        
+        app.goTo(tab: "Home")
+        
+        XCTAssertTrue(app.navigationBars.buttons["Your Account"].waitForExistence(timeout: 2))
+        app.navigationBars.buttons["Your Account"].tap()
+        
+        XCTAssert(app.buttons["Health Summary"].waitForExistence(timeout: 0.5))
+        app.buttons["Health Summary"].tap()
+        
+        XCTAssertTrue(app.segmentedControls.buttons["PDF"].exists)
+        XCTAssertTrue(app.segmentedControls.buttons["QR Code"].exists)
+        
+        XCTAssertTrue(app.navigationBars.buttons["Share Link"].waitForExistence(timeout: 2))
+        
+        app.segmentedControls.buttons["QR Code"].tap()
+        
+        XCTAssertTrue(app.navigationBars.buttons["Share Link"].waitForExistence(timeout: 2))
+        XCTAssertTrue(app.staticTexts["Health Summary QR Code"].waitForExistence(timeout: 5))
+        XCTAssertTrue(app.staticTexts["One-time Code"].waitForExistence(timeout: 2))
+    }
+}


### PR DESCRIPTION
# *Add QR Code Sharing View for Health Summary*

## :recycle: Current situation & Problem
Currently, the user can only export their health summary in form of a pdf file. For a more efficient and secure sharing of patient's health summary with the physician, the export should be extended by a new view that shows a QR and one-time code that the physician can scan to get access to the patient's health summary.

## :gear: Release Notes
This PR adds a view that shows the QR and one-time code using the new `shareHealthSummary` cloud function. The view can be accessed via the Account view in the Health Summary section. A segmented picker has been added to the navigation bar in the sheet to switch between the PDF view and the new QR code view.

![Simulator Screenshot - iPhone 16 Pro - 2025-03-11 at 14 51 12 Medium](https://github.com/user-attachments/assets/37eef562-66bd-47e1-a4da-70c3f92294b3)

## :white_check_mark: Testing
UI tests have been added to test the basic elements of the healthy summary share sheet.

### Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).
