### PR TITLE
Avoid parallel Questionnaire Result Handling

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -55,7 +55,7 @@ platform :ios do
       ],
       build_for_testing: true
     )
-
+    
     snapshot(
       test_without_building: true,
       derived_data_path: ".derivedData",
@@ -160,12 +160,18 @@ platform :ios do
 
     releasenotes = releasenotes.gsub('\u2019', "'")
 
-    if environment == "production"
+    currentversion = get_version_number()
+    UI.message("Current version: #{currentversion}")
+
+    if Gem::Version.new(versionname) > Gem::Version.new(currentversion)
       increment_version_number(
         version_number: versionname
       )
+      UI.message("Version bumped to #{versionname}")
+    else
+      UI.message("No version bump needed. Current version (#{currentversion}) is greater than or equal to desired version (#{versionname}).")
     end
-    
+
     signin
     latest_build_number = latest_testflight_build_number(
       app_identifier: appidentifier
@@ -178,7 +184,7 @@ platform :ios do
       provisioningProfile: provisioningProfile,
     )
     commit = last_git_commit
-    
+
     if environment == "production"
       deliver(
         app_identifier: appidentifier,


### PR DESCRIPTION
# Avoid parallel Questionnaire Result Handling

## :recycle: Current situation & Problem
A patient was able to store multiple questionnaire responses by repeatedly tapping the Finish button. Since the screen is still visible while we are uploading the response, the action may be performed multiple times, which we want to avoid.

## :gear: Release Notes
*Add a bullet point list summary of the feature and possible migration guides if this is a breaking change so this section can be added to the release notes.*
*Include code snippets that provide examples of the feature implemented or links to the documentation if it appends or changes the public interface.*


## :books: Documentation
*Please ensure that you properly document any additions in conformance to [Spezi Documentation Guide](https://github.com/StanfordSpezi/.github/blob/main/DOCUMENTATIONGUIDE.md).*
*You can use this section to describe your solution, but we encourage contributors to document your reasoning and changes using in-line documentation.* 


## :white_check_mark: Testing
*Please ensure that the PR meets the testing requirements set by CodeCov and that new functionality is appropriately tested.*
*This section describes important information about the tests and why some elements might not be testable.*


### Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).
