### PR TITLE
Add Build Number Parameter

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -29,6 +29,11 @@ on:
           The semantic version of the app that should be released.
         required: true
         type: string
+      buildnumber:
+        description: |
+          Optional build number to use for deployment.
+        required: false
+        type: string
       releasenotes:
         description: |
           Release notes of what changed in this version.
@@ -47,6 +52,11 @@ on:
         description: |
           The semantic version of the app that should be released.
         required: true
+        type: string
+      buildnumber:
+        description: |
+          Optional build number to use for deployment.
+        required: false
         type: string
       releasenotes:
         description: |
@@ -134,5 +144,5 @@ jobs:
       environment: ${{ needs.determineenvironment.outputs.environment }}
       googleserviceinfoplistpath: 'ENGAGEHF/Supporting Files/GoogleService-Info.plist'
       setupsigning: true
-      fastlanelane: deploy environment:"${{ needs.determineenvironment.outputs.environment }}" appidentifier:"${{ needs.vars.outputs.appidentifier }}" provisioningProfile:"${{ needs.vars.outputs.provisioningProfileName }}" versionname:"${{ needs.vars.outputs.version }}" releasenotes:"${{ inputs.releasenotes }}"
+      fastlanelane: deploy environment:"${{ needs.determineenvironment.outputs.environment }}" appidentifier:"${{ needs.vars.outputs.appidentifier }}" provisioningProfile:"${{ needs.vars.outputs.provisioningProfileName }}" versionname:"${{ needs.vars.outputs.version }}" releasenotes:"${{ inputs.releasenotes }}" ${{ inputs.buildnumber && format('buildnumber:"{0}"', inputs.buildnumber) || '' }}
     secrets: inherit

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -173,12 +173,21 @@ platform :ios do
     end
 
     signin
-    latest_build_number = latest_testflight_build_number(
-      app_identifier: appidentifier
-    )
+    
+    buildnumber = options[:buildnumber].to_s.strip
+    if buildnumber.empty?
+      latest_build_number = latest_testflight_build_number(
+        app_identifier: appidentifier
+      )
+      buildnumber = latest_build_number + 1
+      UI.message("No build number provided. Incrementing to #{buildnumber}.")
+    else
+      UI.message("Using provided build number: #{buildnumber}.")
+    end
     increment_build_number(
-      build_number: latest_build_number + 1
+      build_number: buildnumber
     )
+    
     archive(
       appidentifier: appidentifier,
       provisioningProfile: provisioningProfile,


### PR DESCRIPTION
# Add Build Number Parameter

## :recycle: Current situation & Problem
- If an upload fails the automatic incrementing of build numbers does no longer work; we need to manually push a proper update. This currently needs to happen from a Mac with access to the App Store Connect account.


## :gear: Release Notes
- Add Build Number Parameter


### Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).
